### PR TITLE
Add GitHub actions for compiling CodeHawk.

### DIFF
--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -1,0 +1,18 @@
+name: CI
+
+on: [pull_request, push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - uses: avsm/setup-ocaml@v1.0
+    - name: Install dependencies
+      run: |
+        opam install zarith
+        opam install ocamlbuild
+    - name: Compile CodeHawk
+      run: eval $(opam env) && cd CodeHawk && ./full_make.sh

--- a/CodeHawk/full_clean.sh
+++ b/CodeHawk/full_clean.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+make -C CH_extern/extlib clean
+make -C CH_extern/camlzip clean
+make -C CH/chlib clean
+make -C CH/chutil clean
+make -C CH/xprlib clean
+make -C CHC/cil-1.7.3-develop clean
+make -C CHC/cchcil clean
+make -C CHC/cchlib clean
+make -C CHC/cchpre clean
+make -C CHC/cchanalyze clean
+make -C CHC/cchcmdline clean
+make -C CHB/bchlib clean
+make -C CHB/bchlibpe clean
+make -C CHB/bchlibelf clean
+make -C CHB/bchlibx86 clean
+make -C CHB/bchlibmips32 clean
+make -C CHB/bchanalyze clean
+make -C CHB/bchcmdline clean

--- a/CodeHawk/full_make.sh
+++ b/CodeHawk/full_make.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+make -C CH_extern/extlib
+make -C CH_extern/camlzip
+make -C CH/chlib
+make -C CH/chutil
+make -C CH/xprlib
+make -C CHC/cil-1.7.3-develop
+make -C CHC/cchcil
+make -C CHC/cchlib
+make -C CHC/cchpre
+make -C CHC/cchanalyze
+make -C CHC/cchcmdline
+make -C CHB/bchlib
+make -C CHB/bchlibpe
+make -C CHB/bchlibelf
+make -C CHB/bchlibx86
+make -C CHB/bchlibmips32
+make -C CHB/bchanalyze
+make -C CHB/bchcmdline


### PR DESCRIPTION
These are triggered on pushing new versions, and on new pull requests
being submitted. It's based on the experimental "setup-ocaml" GitHub action:
https://github.com/avsm/setup-ocaml

"setup-ocaml" really sets up opam, which is used to fetch recent
versions of ocaml, ocamlbuild, and zarith. The default appears to be
4.07 at this time, but it is possible to configure this action to test
multiple versions of ocaml. For example:
https://github.com/avsm/setup-ocaml#example-workflow

This workflow comes from an ocaml maintainer:
https://discuss.ocaml.org/t/github-actions-for-ocaml-opam-now-available/4745