### PR TITLE
Upgrade ocaml in installation instructions and github actions

### DIFF
--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: avsm/setup-ocaml@v1
       with:
-        ocaml-version: 4.09.0
+        ocaml-version: 4.11.2
     - name: Install dependencies
       run: |
         opam install extlib camlzip zarith ocamlbuild goblint-cil=1.8.2

--- a/.github/workflows/test_b_orchestration.yaml
+++ b/.github/workflows/test_b_orchestration.yaml
@@ -20,7 +20,7 @@ jobs:
         rm CodeHawk-Binary/chb/bin/binaries/linux/chx86_analyze
     - uses: avsm/setup-ocaml@v1
       with:
-        ocaml-version: 4.09.0
+        ocaml-version: 4.11.2
     - name: Install dependencies
       run: |
         opam install extlib camlzip zarith ocamlbuild goblint-cil=1.8.2

--- a/.github/workflows/test_c_orchestration.yaml
+++ b/.github/workflows/test_c_orchestration.yaml
@@ -21,7 +21,7 @@ jobs:
         rm CodeHawk-C/chc/bin/linux/parseFile
     - uses: avsm/setup-ocaml@v1
       with:
-        ocaml-version: 4.09.0
+        ocaml-version: 4.11.2
     - name: Install dependencies
       run: |
         opam install extlib camlzip zarith ocamlbuild goblint-cil=1.8.2

--- a/CodeHawk/README.md
+++ b/CodeHawk/README.md
@@ -24,8 +24,8 @@ sudo apt update -y
 sudo apt install opam
 git clone https://github.com/static-analysis-engineering/codehawk.git
 opam init --bare --no-setup --disable-sandboxing
-opam switch create codehawk-4.09.0 4.09.0 --no-switch
-eval $(opam env --switch=codehawk-4.09.0 --set-switch)
+opam switch create codehawk-4.11.2 4.11.2 --no-switch
+eval $(opam env --switch=codehawk-4.11.2 --set-switch)
 opam install ocamlfind zarith camlzip extlib goblint-cil
 cd codehawk/CodeHawk
 ```
@@ -52,8 +52,8 @@ sudo apt update -y
 sudo apt install opam
 git clone https://github.com/static-analysis-engineering/codehawk.git
 opam init --bare --no-setup --disable-sandboxing
-opam switch create codehawk-4.09.0 4.09.0 --no-switch
-eval $(opam env --switch=codehawk-4.09.0 --set-switch)
+opam switch create codehawk-4.11.2 4.11.2 --no-switch
+eval $(opam env --switch=codehawk-4.11.2 --set-switch)
 opam install ocamlfind zarith camlzip extlib lablgtk lablgtk-extras goblint-cil
 cd codehawk/CodeHawk
 ./full_make.sh
@@ -166,8 +166,8 @@ Before the final "shake" command in one of the above instructions:
 
 ```
 opam init --bare --no-setup --disable-sandboxing
-opam switch create codehawk-4.09.0 4.09.0 --no-switch
-eval $(opam env --switch=codehawk-4.09.0 --set-switch)
+opam switch create codehawk-4.11.2 4.11.2 --no-switch
+eval $(opam env --switch=codehawk-4.11.2 --set-switch)
 opam install ocamlfind zarith camlzip extlib lablgtk lablgtk-extras
 /path/to/shake
 ```


### PR DESCRIPTION
4.11.2 is the most recent version that doesn't introduce any additional warnings in the existing code.