### PR TITLE
Upgrade to ocaml 4.12.1

### DIFF
--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: avsm/setup-ocaml@v1
       with:
-        ocaml-version: 4.09.0
+        ocaml-version: 4.12.1
     - name: Install dependencies
       run: |
         opam install extlib camlzip zarith ocamlbuild goblint-cil=1.8.2

--- a/.github/workflows/test_b_orchestration.yaml
+++ b/.github/workflows/test_b_orchestration.yaml
@@ -20,7 +20,7 @@ jobs:
         rm CodeHawk-Binary/chb/bin/binaries/linux/chx86_analyze
     - uses: avsm/setup-ocaml@v1
       with:
-        ocaml-version: 4.09.0
+        ocaml-version: 4.12.1
     - name: Install dependencies
       run: |
         opam install extlib camlzip zarith ocamlbuild goblint-cil=1.8.2

--- a/.github/workflows/test_c_orchestration.yaml
+++ b/.github/workflows/test_c_orchestration.yaml
@@ -21,7 +21,7 @@ jobs:
         rm CodeHawk-C/chc/bin/linux/parseFile
     - uses: avsm/setup-ocaml@v1
       with:
-        ocaml-version: 4.09.0
+        ocaml-version: 4.12.1
     - name: Install dependencies
       run: |
         opam install extlib camlzip zarith ocamlbuild goblint-cil=1.8.2

--- a/CodeHawk/CHB/bchlib/bCHJumpTable.ml
+++ b/CodeHawk/CHB/bchlib/bCHJumpTable.ml
@@ -192,7 +192,8 @@ end
 let make_jumptable
       ?(end_address: doubleword_int option=None)
       ~(start_address:doubleword_int)
-      ~(targets:doubleword_int list): jumptable_int TR.traceresult =
+      ~(targets:doubleword_int list)
+      (): jumptable_int TR.traceresult =
   let end_address =
     match end_address with
     | Some e -> e
@@ -213,7 +214,7 @@ let split_jumptable
     List.fold_left (fun (offset, jts) size ->
         let start_address = startaddr#add_int (offset *  4) in
         let targets = list_sub alltargets offset size in
-        let newtable = make_jumptable ~end_address:None ~start_address ~targets in
+        let newtable = make_jumptable ~end_address:None ~start_address ~targets () in
         TR.tfold
           ~ok:(fun jt -> (offset + size, jt::jts))
           ~error:(fun _ -> (offset + size, jts))
@@ -233,7 +234,7 @@ let read_xml_jumptable (node:xml_element_int) =
   let table =
     TR.tbind
       ~msg:("BCHJumpTable.read_xml_jumptable")
-      (fun saddr -> make_jumptable saddr targets)
+      (fun saddr -> make_jumptable saddr targets ())
       startAddress in
   TR.tbind (fun jt ->
       begin
@@ -265,7 +266,7 @@ let find_jumptable is_code_address ch len start_address target1 =
             (mk_tracelog_spec ~tag:"find_jumptable" start_address#to_hex_string)
             (fun jt -> Some jt)
             None
-            (make_jumptable ~end_address:None ~start_address:start ~targets))
+            (make_jumptable ~end_address:None ~start_address:start ~targets ()))
       None
       trdiff in
 
@@ -349,7 +350,7 @@ let find2_jumptable is_code_address ch len start_address target1 =
             (mk_tracelog_spec ~tag:"find2_jumptable" start_address#to_hex_string)
             (fun jt -> Some jt)
             None
-	    (make_jumptable start_address (List.rev !targets))
+	    (make_jumptable start_address (List.rev !targets) ())
 	end
       else None
     else None

--- a/CodeHawk/CHB/bchlib/bCHJumpTable.mli
+++ b/CodeHawk/CHB/bchlib/bCHJumpTable.mli
@@ -38,6 +38,7 @@ val make_jumptable:
   ?end_address: doubleword_int option
   -> start_address:doubleword_int
   -> targets:doubleword_int list
+  -> unit
   -> jumptable_int traceresult
   
 val split_jumptable:

--- a/CodeHawk/CHB/bchlib/bCHVersion.ml
+++ b/CodeHawk/CHB/bchlib/bCHVersion.ml
@@ -47,7 +47,8 @@ class version_info_t
   ?(maxfilesize=None)
   ?(licensee=None)
   ~(version:string)
-  ~(date:string) =
+  ~(date:string)
+  () =
 object (self)
 
   method get_version = version
@@ -98,3 +99,4 @@ let version = new version_info_t
   ~date:"2023-03-25"
   ~licensee: None
   ~maxfilesize: None
+  ()

--- a/CodeHawk/CHB/bchlib/bCHVersion.mli
+++ b/CodeHawk/CHB/bchlib/bCHVersion.mli
@@ -13,6 +13,7 @@ class version_info_t :
   -> ?licensee:string option
   -> version:string
   -> date:string
+  -> unit
   -> object
     method get_date: string
     method get_licensee: string option

--- a/CodeHawk/CHB/bchlibarm32/bCHARMJumptable.ml
+++ b/CodeHawk/CHB/bchlibarm32/bCHARMJumptable.ml
@@ -54,7 +54,8 @@ class arm_jumptable_t
         ?(end_address: doubleword_int option=None)
         ~(start_address: doubleword_int)
         ~(default_target: doubleword_int)
-        ~(targets: (doubleword_int * int list) list):arm_jumptable_int =
+        ~(targets: (doubleword_int * int list) list)
+        ():arm_jumptable_int =
 object (self)
 
   method start_address = start_address
@@ -97,7 +98,8 @@ let make_arm_jumptable
       ?(end_address: doubleword_int option=None)
       ~(start_address: doubleword_int)
       ~(default_target: doubleword_int)
-      ~(targets: (doubleword_int * int) list) =
+      ~(targets: (doubleword_int * int) list)
+      () =
   let tgts = H.create 5 in
   let _ =
     List.iter (fun (tgt, v) ->
@@ -120,6 +122,7 @@ let make_arm_jumptable
     ~start_address:start_address
     ~default_target:default_target
     ~targets:indexedtargets
+    ()
 
 
 let find_instr
@@ -291,7 +294,8 @@ let create_arm_table_branch
             ~end_address:(Some end_address)
             ~start_address:jtaddr
             ~default_target:defaulttgt
-            ~targets:(List.rev !targets) in
+            ~targets:(List.rev !targets)
+            () in
         let instrs = [cmpinstr; bhiinstr; tbinstr] in
         begin
           (* system_info#add_jumptable jt;
@@ -378,7 +382,8 @@ let create_arm_ldr_jumptable
              ~end_address:(Some (jtaddr#add_int (4 * (List.length !targets))))
              ~start_address:jtaddr
              ~default_target:defaulttgt
-             ~targets:(List.rev !targets) in
+             ~targets:(List.rev !targets)
+             () in
          let instrs = [cmpinstr; bhiinstr; adrinstr; ldrinstr] in
          begin
            (* system_info#add_jumptable jt;
@@ -457,7 +462,8 @@ let create_arm_ldrls_jumptable
              ~end_address:(Some (jtaddr#add_int ((List.length !targets) * 4)))
              ~start_address:jtaddr
              ~default_target:defaulttgt
-             ~targets:(List.rev !targets) in
+             ~targets:(List.rev !targets)
+             () in
          let instrs = [cmpinstr; ldrinstr; branchinstr] in
          begin
            (if collect_diagnostics () then
@@ -641,7 +647,8 @@ let create_arm_bx_jumptable
          ~end_address:(Some (jtaddr#add_int (4 * (List.length !targets))))
          ~start_address:jtaddr
          ~default_target:defaulttgt
-         ~targets:(List.rev !targets) in
+         ~targets:(List.rev !targets)
+         () in
      let instrs = [
          cmpinstr; bhiinstr; adrinstr; ldrinstr; addinstr; bxinstr] in
      begin

--- a/CodeHawk/CHB/bchlibarm32/bCHARMJumptable.ml
+++ b/CodeHawk/CHB/bchlibarm32/bCHARMJumptable.ml
@@ -72,7 +72,7 @@ object (self)
       (make_jumptable
          ~end_address:self#end_address
          ~start_address
-         ~targets:(self#default_target :: self#target_addrs))
+         ~targets:(self#default_target :: self#target_addrs) ())
 
   method toCHIF (faddr: doubleword_int) = []
 

--- a/CodeHawk/CHT/CHB_tests/bchlibarm32_tests/tbchlibarm32/tCHBchlibarm32Assertion.ml
+++ b/CodeHawk/CHT/CHB_tests/bchlibarm32_tests/tbchlibarm32/tCHBchlibarm32Assertion.ml
@@ -48,7 +48,8 @@ let x2s x = pretty_to_string (xpr_formatter#pr_expr x)
 let equal_jumptable_targets
       ?(msg="")
       ~(expected: (string * int list) list)
-      ~(received: arm_jumptable_int) =
+      ~(received: arm_jumptable_int)
+      () =
     A.make_equal_list
       (fun (tgt1, ixs1) (tgt2, ixs2) ->
              (tgt1 = tgt2)
@@ -67,7 +68,8 @@ let equal_jumptable_targets
 let equal_cfg_edges
       ?(msg="")
       ~(expected: (string * string) list)
-      ~(received: (string * string) list) =
+      ~(received: (string * string) list)
+      () =
   A.make_equal_list
     (fun (src1, tgt1) (src2, tgt2) ->
       (src1 = src2) && (tgt1 = tgt2))
@@ -80,7 +82,8 @@ let equal_cfg_edges
 let equal_chif_conditionxprs
       ?(msg="")
       ~(expected: string)
-      ~(received: xpr_t list) =
+      ~(received: xpr_t list)
+      () =
   match received with
   | [] -> A.fail expected "empty list" msg
   | [x] -> A.equal_string ~msg expected (x2s x)
@@ -96,7 +99,8 @@ let equal_instrxdata_conditionxprs
       ?(msg="")
       ~(expected: string)
       ~(received: xpr_t list)
-      ~(index: int) =
+      ~(index: int)
+      () =
   match received with
   | [] -> A.fail expected "empty list" msg
   | _ when (List.length received) > index ->
@@ -120,7 +124,8 @@ let equal_instrxdata_tags
       ?(msg="")
       ~(expected: string)
       ~(received: string list)
-      ~(indices: int list) =
+      ~(indices: int list)
+      () =
   match received with
   | [] -> A.fail expected "empty list" msg
   | _  ->
@@ -135,7 +140,8 @@ let equal_instrxdata_tags
 let equal_dictionary_key
       ?(msg="")
       ~(expected: (string list * int))
-      ~(received: (string list * int list)) =
+      ~(received: (string list * int list))
+      () =
   let keystr (sl, l) =
     "([" ^ (String.concat "; " sl) ^ "], " ^ (string_of_int l) ^ ")" in
   let rkeystr (sl, il) = keystr (sl, List.length il) in

--- a/CodeHawk/CHT/CHB_tests/bchlibarm32_tests/tbchlibarm32/tCHBchlibarm32Assertion.mli
+++ b/CodeHawk/CHT/CHB_tests/bchlibarm32_tests/tbchlibarm32/tCHBchlibarm32Assertion.mli
@@ -41,6 +41,7 @@ val equal_jumptable_targets:
   -> expected:(string * int list) list
   -> received:arm_jumptable_int
   -> unit
+  -> unit
 
 
 val equal_cfg_edges:
@@ -48,12 +49,14 @@ val equal_cfg_edges:
   -> expected:(string * string) list
   -> received:(string * string) list
   -> unit
+  -> unit
 
 
 val equal_chif_conditionxprs:
   ?msg:string
   -> expected:string
   -> received:xpr_t list
+  -> unit
   -> unit
 
 
@@ -63,6 +66,7 @@ val equal_instrxdata_conditionxprs:
   -> received:xpr_t list
   -> index:int
   -> unit
+  -> unit
 
 
 val equal_instrxdata_tags:
@@ -71,10 +75,12 @@ val equal_instrxdata_tags:
   -> received:string list
   -> indices:int list
   -> unit
+  -> unit
 
 
 val equal_dictionary_key:
   ?msg: string
   -> expected:(string list * int)
   -> received:(string list * int list)
+  -> unit
   -> unit

--- a/CodeHawk/CHT/CHB_tests/bchlibarm32_tests/txbchlibarm32/bCHARMAssemblyFunctionTest.ml
+++ b/CodeHawk/CHT/CHB_tests/bchlibarm32_tests/txbchlibarm32/bCHARMAssemblyFunctionTest.ml
@@ -113,7 +113,7 @@ let conditional_return () =
             let faddr = make_dw sfaddr in
             let fn = ARMU.arm_function_setup faddr bytes in
             begin
-              ARMA.equal_cfg_edges fn#get_cfg_edges expectedresult
+              ARMA.equal_cfg_edges fn#get_cfg_edges expectedresult ()
             end)
       ) tests;
 

--- a/CodeHawk/CHT/CHB_tests/bchlibarm32_tests/txbchlibarm32/bCHARMJumptableTest.ml
+++ b/CodeHawk/CHT/CHB_tests/bchlibarm32_tests/txbchlibarm32/bCHARMJumptableTest.ml
@@ -203,7 +203,7 @@ let tb_table_branch () =
             match jtresult with
             | Ok jt ->
                ARMA.equal_jumptable_targets
-                 ~msg:"" ~expected:expectedtargets ~received:jt
+                 ~msg:"" ~expected:expectedtargets ~received:jt ()
             | Error e ->
                A.fail_msg (String.concat "; " e));
 
@@ -241,7 +241,7 @@ let ldr_table_branch () =
             match jtresult with
             | Ok jt ->
                ARMA.equal_jumptable_targets
-                 ~msg:"" ~expected:expectedtargets ~received:jt
+                 ~msg:"" ~expected:expectedtargets ~received:jt ()
             | Error e ->
                A.fail_msg (String.concat "; " e));
 
@@ -280,7 +280,7 @@ let ldrls_jumptable () =
             match jtresult with
             | Ok jt ->
                ARMA.equal_jumptable_targets
-                 ~msg:"" ~expected:expectedtargets ~received:jt
+                 ~msg:"" ~expected:expectedtargets ~received:jt ()
             | Error e ->
                A.fail_msg (String.concat "; " e));
 
@@ -332,7 +332,7 @@ let bx_table_branch () =
             match jtresult with
             | Ok jt ->
                ARMA.equal_jumptable_targets
-                 ~msg:"" ~expected:expectedtargets ~received:jt
+                 ~msg:"" ~expected:expectedtargets ~received:jt ()
             | Error e ->
                A.fail_msg (String.concat "; " e));
 

--- a/CodeHawk/CHT/CHB_tests/bchlibarm32_tests/txbchlibarm32/bCHTranslateARMToCHIFTest.ml
+++ b/CodeHawk/CHT/CHB_tests/bchlibarm32_tests/txbchlibarm32/bCHTranslateARMToCHIFTest.ml
@@ -205,7 +205,7 @@ let thumb_chif_conditionxprs () =
             let _ = TF.translate_arm_assembly_function fn in
             let (_, _, txprs) =
               TR.tget_ok (testsupport#retrieve_chif_conditionxprs ccaddr) in
-            ARMA.equal_chif_conditionxprs expectedcond txprs)
+            ARMA.equal_chif_conditionxprs expectedcond txprs ())
       ) tests;
 
     TS.launch_tests ()
@@ -258,7 +258,7 @@ let thumb_instrxdata_conditionxprs () =
                 analyze_arm_function faddr fn 0
               done in
             let xprs = ARMU.get_instrxdata_xprs faddr iccaddr in
-            ARMA.equal_instrxdata_conditionxprs expectedcond xprs 3)
+            ARMA.equal_instrxdata_conditionxprs expectedcond xprs 3 ())
       ) tests;
 
     TS.launch_tests ()

--- a/CodeHawk/CHT/CHB_tests/bchlibelf_tests/tbchlibelf/tCHBchlibelfAssertion.ml
+++ b/CodeHawk/CHT/CHB_tests/bchlibelf_tests/tbchlibelf/tCHBchlibelfAssertion.ml
@@ -39,7 +39,8 @@ module A = TCHAssertion
 let equal_abbrev_entry
       ?(msg="")
       ~(expected: (int * string * bool * (string * string) list))
-      ~(received: debug_abbrev_table_entry_t) =
+      ~(received: debug_abbrev_table_entry_t)
+      () =
   let (x_index, x_tag, x_hasc, x_attrspecs) = expected in
   if not (x_index = received.dabb_index) then
     let s_expect = "abbrev: " ^ (string_of_int x_index) in
@@ -67,7 +68,8 @@ let equal_abbrev_entry
 let equal_compilation_unit_header
       ?(msg="")
       ~(expected: (string * int * string * int))
-      ~(received: debug_compilation_unit_header_t) =
+      ~(received: debug_compilation_unit_header_t)
+      () =
   let (clen, cversion, coffset, csize) = expected in
   if not (received.dwcu_length#to_hex_string = clen) then
     A.fail clen received.dwcu_length#to_hex_string msg
@@ -95,7 +97,8 @@ let equal_compilation_unit
            * int
            * dwarf_tag_type_t
            * (dwarf_attr_type_t * string) list))
-      ~(received: debug_compilation_unit_t) =
+      ~(received: debug_compilation_unit_t)
+      () =
   let (xlen, xoffset, xnr, xtag, attrs) = expected in
   let hdr = received.cu_header in
   let cu = received.cu_unit in

--- a/CodeHawk/CHT/CHB_tests/bchlibelf_tests/tbchlibelf/tCHBchlibelfAssertion.mli
+++ b/CodeHawk/CHT/CHB_tests/bchlibelf_tests/tbchlibelf/tCHBchlibelfAssertion.mli
@@ -38,12 +38,14 @@ val equal_abbrev_entry:
   -> expected:(int * string * bool * (string * string) list)
   -> received:debug_abbrev_table_entry_t
   -> unit
+  -> unit
 
 
 val equal_compilation_unit_header:
   ?msg:string
   -> expected:(string * int * string * int)
   -> received: debug_compilation_unit_header_t
+  -> unit
   -> unit
 
 
@@ -56,4 +58,5 @@ val equal_compilation_unit:
         * dwarf_tag_type_t
         * (dwarf_attr_type_t * string) list)
   -> received: debug_compilation_unit_t
+  -> unit
   -> unit

--- a/CodeHawk/CHT/CHB_tests/bchlibelf_tests/txbchlibelf/bCHDwarfTest.ml
+++ b/CodeHawk/CHT/CHB_tests/bchlibelf_tests/txbchlibelf/bCHDwarfTest.ml
@@ -85,7 +85,7 @@ let decode_decompilation_unit_header_test () =
             let bytestring = U.write_hex_bytes_to_bytestring bytes in
             let ch = make_pushback_stream ~little_endian:false bytestring in
             let cuheader = decode_compilation_unit_header ch in
-            EA.equal_compilation_unit_header result cuheader)) tests;
+            EA.equal_compilation_unit_header result cuheader ())) tests;
 
     TS.launch_tests ()
   end
@@ -194,7 +194,7 @@ let decode_compilation_unit_test () =
             let chi = make_pushback_stream ~little_endian:false istring in
             let base = TR.tget_ok (string_to_doubleword base) in            
             let cu = decode_compilation_unit chi base fabbrev in
-            EA.equal_compilation_unit result cu)) tests;
+            EA.equal_compilation_unit result cu ())) tests;
 
     TS.launch_tests ()
   end

--- a/CodeHawk/CHT/CHB_tests/bchlibelf_tests/txbchlibelf/bCHELFDebugAbbrevSectionTest.ml
+++ b/CodeHawk/CHT/CHB_tests/bchlibelf_tests/txbchlibelf/bCHELFDebugAbbrevSectionTest.ml
@@ -244,7 +244,7 @@ let get_abbrev_entry_test () =
             let sectionheader = mk_elf_section_header () in
             let section = mk_elf_debug_abbrev_section bytestring sectionheader in
             let abbreventry = section#get_abbrev_entry in
-            EA.equal_abbrev_entry result abbreventry)) tests;
+            EA.equal_abbrev_entry result abbreventry ())) tests;
 
     TS.launch_tests ()
   end

--- a/CodeHawk/README.md
+++ b/CodeHawk/README.md
@@ -24,8 +24,8 @@ sudo apt update -y
 sudo apt install opam
 git clone https://github.com/static-analysis-engineering/codehawk.git
 opam init --bare --no-setup --disable-sandboxing
-opam switch create codehawk-4.09.0 4.09.0 --no-switch
-eval $(opam env --switch=codehawk-4.09.0 --set-switch)
+opam switch create codehawk-4.12.1 4.09.0 --no-switch
+eval $(opam env --switch=codehawk-4.12.1 --set-switch)
 opam install ocamlfind zarith camlzip extlib goblint-cil
 cd codehawk/CodeHawk
 ```
@@ -52,8 +52,8 @@ sudo apt update -y
 sudo apt install opam
 git clone https://github.com/static-analysis-engineering/codehawk.git
 opam init --bare --no-setup --disable-sandboxing
-opam switch create codehawk-4.09.0 4.09.0 --no-switch
-eval $(opam env --switch=codehawk-4.09.0 --set-switch)
+opam switch create codehawk-4.12.1 4.09.0 --no-switch
+eval $(opam env --switch=codehawk-4.12.1 --set-switch)
 opam install ocamlfind zarith camlzip extlib lablgtk lablgtk-extras goblint-cil
 cd codehawk/CodeHawk
 ./full_make.sh
@@ -166,8 +166,8 @@ Before the final "shake" command in one of the above instructions:
 
 ```
 opam init --bare --no-setup --disable-sandboxing
-opam switch create codehawk-4.09.0 4.09.0 --no-switch
-eval $(opam env --switch=codehawk-4.09.0 --set-switch)
+opam switch create codehawk-4.12.1 4.09.0 --no-switch
+eval $(opam env --switch=codehawk-4.12.1 --set-switch)
 opam install ocamlfind zarith camlzip extlib lablgtk lablgtk-extras
 /path/to/shake
 ```

--- a/CodeHawk/Shakefile.hs
+++ b/CodeHawk/Shakefile.hs
@@ -327,7 +327,8 @@ runBuild flags = do
                  ("bCHDisassembleThumbInstructionTest", "bCHDisassembleThumbInstructionTest.ml"),
                  ("bCHTranslateARMToCHIFTest", "bCHTranslateARMToCHIFTest.ml"),
                  ("bCHDisassemblePowerInstructionTest", "bCHDisassemblePowerInstructionTest.ml"),
-                 ("bCHDisassembleVLEInstructionTest", "bCHDisassembleVLEInstructionTest.ml")
+                 ("bCHDisassembleVLEInstructionTest", "bCHDisassembleVLEInstructionTest.ml"),
+                 ("bCHDwarfTest", "bCHDwarfTest.ml")
                 ]
 
     forM_ (exes ++ tests) (\pair -> do


### PR DESCRIPTION
This PR also adds a missing shake test, and fixes warnings introduced by the new compiler version.