### PR TITLE
chlib: Fix all warnings enabled by dune

### DIFF
--- a/CodeHawk/CH/chlib/cHAtlasTable.ml
+++ b/CodeHawk/CH/chlib/cHAtlasTable.ml
@@ -28,7 +28,6 @@
 (* chlib *)
 open CHAtlas
 open CHCommon   
-open CHPretty
 
 module Make (S: STOREABLE) =
 struct
@@ -38,7 +37,7 @@ struct
   open C
 
   class atlas_table_t =
-  object (self: 'a)
+  object (_self: 'a)
     
     val table = new table_t
 

--- a/CodeHawk/CH/chlib/cHBitstring.ml
+++ b/CodeHawk/CH/chlib/cHBitstring.ml
@@ -27,8 +27,6 @@
 
 (* chlib *)
 open CHCommon
-open CHNumerical
-open CHPretty
    
 
 let bitstring_size = 16
@@ -39,7 +37,7 @@ let bitindex_size (n: int) =
 
 
 class bitstring_t (n: int32) =
-object (self: 'a)
+object (_self: 'a)
   
   val _b: int32 = n
   
@@ -96,7 +94,7 @@ let bitstring_cmp (r1: bitstring_t array) (r2: bitstring_t array) =
     !res
 
 class bitindex_t (col: int) =
-object (self: 'a)
+object (_self: 'a)
   
   val mutable _index: int = col
 

--- a/CodeHawk/CH/chlib/cHBooleanConstantsDomainNoArrays.ml
+++ b/CodeHawk/CH/chlib/cHBooleanConstantsDomainNoArrays.ml
@@ -49,12 +49,12 @@ object (self: 'a)
   method private setValue' t v x =
     self#setValue t v (new non_relational_domain_value_t (BOOL_CONSTANT_VAL x))
 
-  method special cmd args = {< >}
+  method special _cmd _args = {< >}
 
   method private importValue v =
     new non_relational_domain_value_t (NUM_CONSTANT_VAL (v#toNumericalConstant))
 
-  method importNumericalConstraints (csts: numerical_constraint_t list) = {< >}
+  method! importNumericalConstraints (_csts: numerical_constraint_t list) = {< >}
 
   method private analyzeFwd' (cmd: (code_int, cfg_int) command_t) =
     if bottom then

--- a/CodeHawk/CH/chlib/cHChernikova.ml
+++ b/CodeHawk/CH/chlib/cHChernikova.ml
@@ -358,7 +358,7 @@ let backsubstitute (intp: int array) (con: matrix_t) (rank: int) =
       done
     end
 
-let simplify (con: matrix_t) (ray: matrix_t) (satf: satmat_t) (nbline: int) =
+let simplify (con: matrix_t) (ray: matrix_t) (satf: satmat_t) (_nbline: int) =
   let i = ref 0 in
   let j = ref 0 in
   let nb = ref 0 in
@@ -697,7 +697,7 @@ let add_dimensions (_C: matrix_t option) (_F: matrix_t option)
 	p_satCres := !nsatC
       end
 
-let checksatmat (con_to_ray: bool) (c: matrix_t) (f: matrix_t) (satC: satmat_t) =
+let checksatmat (_con_to_ray: bool) (c: matrix_t) (f: matrix_t) (satC: satmat_t) =
   try
     for i = 0 to f#nbrows - 1 do
       let j = new bitindex_t 0 in
@@ -717,7 +717,7 @@ let checksatmat (con_to_ray: bool) (c: matrix_t) (f: matrix_t) (satC: satmat_t) 
     true
   with Found -> false
 
-let checksat (con_to_ray: bool) (c: matrix_t) (nbequations: int)
+let checksat (_con_to_ray: bool) (c: matrix_t) (nbequations: int)
     (f: matrix_t) (nblines: int) (satC: satmat_t) =
   let nb = ref 0 in
   let rank = ref 0 in

--- a/CodeHawk/CH/chlib/cHCommunications.ml
+++ b/CodeHawk/CH/chlib/cHCommunications.ml
@@ -27,7 +27,6 @@
 
 (* chlib *)
 open CHCommon
-open CHDomain
 open CHPretty
 
 class virtual ['a] domain_downlink_int =

--- a/CodeHawk/CH/chlib/cHConstantPropagationNoArrays.ml
+++ b/CodeHawk/CH/chlib/cHConstantPropagationNoArrays.ml
@@ -27,18 +27,14 @@
 
 (* chlib *)
 open CHAtlas
-open CHCommon
 open CHConstants   
-open CHDomain
 open CHIterator   
 open CHLanguage
 open CHNonRelationalDomainValues   
-open CHNumerical
 open CHNumericalConstantsDomainNoArrays   
-open CHPretty
 open CHSymbolicConstantsDomainNoArrays
-open CHUtils
 
+[@@@warning "-27"]
 
 class constant_propagation_no_arrays_t system =
   let simplifier ~invariant ~context ~cmd =

--- a/CodeHawk/CH/chlib/cHConstants.ml
+++ b/CodeHawk/CH/chlib/cHConstants.ml
@@ -28,11 +28,9 @@
   ============================================================================== *)
 
 (* chlib *)
-open CHCommon
 open CHLanguage   
 open CHNumerical   
 open CHPretty
-open CHUtils
 
 
 type num_cst_t =

--- a/CodeHawk/CH/chlib/cHDomain.ml
+++ b/CodeHawk/CH/chlib/cHDomain.ml
@@ -26,7 +26,6 @@
   ============================================================================== *)
 
 (* chlib *)
-open CHCommon
 open CHDomainObserver   
 open CHLanguage
 open CHNonRelationalDomainValues

--- a/CodeHawk/CH/chlib/cHDomainObserver.ml
+++ b/CodeHawk/CH/chlib/cHDomainObserver.ml
@@ -33,8 +33,8 @@ open CHNonRelationalDomainValues
 open CHNumerical
 open CHNumericalConstraints
 open CHPolyhedra   
-open CHUtils
 
+[@@@warning "-27"]
 
 class domain_observer_t =
 object
@@ -43,16 +43,16 @@ object
     
   method getObservedArrays: variable_t list = []
       
-  method getObservedArrayIndices (a: variable_t): numerical_t list = []
+  method getObservedArrayIndices (_a: variable_t): numerical_t list = []
 
   method getObservedFactors: numerical_factor_t list = []
 
   method getNonRelationalVariableObserver: variable_t -> non_relational_domain_value_t =
-    fun v -> topNonRelationalDomainValue      
+    fun _v -> topNonRelationalDomainValue      
 
   method getNonRelationalExtensiveArrayObserver:
            variable_t -> numerical_t -> non_relational_domain_value_t =
-    fun v i -> topNonRelationalDomainValue      
+    fun _v _i -> topNonRelationalDomainValue      
 
   method getNumericalConstraints
            ~(variables: variable_t list option) (): numerical_constraint_t list =

--- a/CodeHawk/CH/chlib/cHGaussSeidelSigmaCombinator.ml
+++ b/CodeHawk/CH/chlib/cHGaussSeidelSigmaCombinator.ml
@@ -26,13 +26,11 @@
   ============================================================================== *)
 
 (* chlib *)
-open CHCommon
 open CHConstants   
 open CHLocalIterationSigmaCombinator
 open CHNonRelationalDomainValues
 open CHIntervals
 open CHNumericalConstraints
-open CHPretty
    
 exception Bottom_found
 

--- a/CodeHawk/CH/chlib/cHIndexedHTable.ml
+++ b/CodeHawk/CH/chlib/cHIndexedHTable.ml
@@ -34,7 +34,7 @@ open CHPretty
 module H = Hashtbl
 
 class indexed_htable_t (name:string):indexed_htable_int =
-object (self)
+object (_self)
 
   val mutable next = 1
   val table = H.create 3

--- a/CodeHawk/CH/chlib/cHIntervalsDomainExtensiveArrays.ml
+++ b/CodeHawk/CH/chlib/cHIntervalsDomainExtensiveArrays.ml
@@ -26,7 +26,6 @@
   ============================================================================== *)
 
 (* chlib *)
-open CHDomain
 open CHIntervalsDomainNoArrays   
 open CHNonRelationalDomainExtensiveArrays
 
@@ -34,9 +33,9 @@ open CHNonRelationalDomainExtensiveArrays
 class intervals_domain_extensive_arrays_t
         ?(do_precise_read_write = false)
         (index_domain: string) =
-object (self: 'a)
+object (_self: 'a)
 
   inherit intervals_domain_no_arrays_t
-  inherit non_relational_domain_extensive_arrays_t do_precise_read_write index_domain
+  inherit! non_relational_domain_extensive_arrays_t do_precise_read_write index_domain
     
 end

--- a/CodeHawk/CH/chlib/cHIntervalsDomainNoArrays.ml
+++ b/CodeHawk/CH/chlib/cHIntervalsDomainNoArrays.ml
@@ -28,15 +28,11 @@
 (* chlib *)
 open CHBounds
 open CHCommon
-open CHConstants   
-open CHDomain
 open CHIntervals   
 open CHLanguage
 open CHNonRelationalDomainNoArrays
 open CHNonRelationalDomainValues   
-open CHNumerical   
 open CHPretty
-open CHUtils
 
   
 class intervals_domain_no_arrays_t =
@@ -53,7 +49,7 @@ object (self: 'a)
   method private setValue' t v x =
     self#setValue t v (new non_relational_domain_value_t (INTERVAL_VAL x))
     
-  method special cmd args = {< >}
+  method special _cmd _args = {< >}
                           
   method private importValue v =
     new non_relational_domain_value_t (INTERVAL_VAL (v#toInterval))
@@ -268,12 +264,12 @@ object (self: 'a)
 	     self#setValue' table' z z_i'';
 	     default()
 	   end	    
-      | ASSIGN_NUM (v, MULT (x, y)) ->
+      | ASSIGN_NUM (v, MULT (_x, _y)) ->
 	 begin
 	   table'#remove v;
 	   default ()
 	 end
-      | ASSIGN_NUM (v, DIV (x, y)) ->
+      | ASSIGN_NUM (v, DIV (_x, _y)) ->
 	 begin
 	   table'#remove v;
 	   default ()

--- a/CodeHawk/CH/chlib/cHIterator.ml
+++ b/CodeHawk/CH/chlib/cHIterator.ml
@@ -30,7 +30,6 @@
 (* chlib *)
 open CHAtlas
 open CHCommon
-open CHDomain   
 open CHLanguage   
 open CHNumerical
 open CHPretty
@@ -231,7 +230,7 @@ object (self: _)
                    loop_stack_table
                    loop_mode_table
                    inv_table
-                   loop_counter_table
+                   _loop_counter_table
                    src
                    tgt
                    inv =
@@ -1151,7 +1150,7 @@ object (self: _)
        up_iteration post_loop 1
     | OPERATION operation ->
        let mods =
-         List.filter (fun (_, v, mode) ->
+         List.filter (fun (_, _v, mode) ->
              match mode with READ -> false | _ -> true) operation.op_args in
        let mods_l = List.map (fun (_, v, _) -> v) mods in
        begin
@@ -1454,7 +1453,7 @@ object (self: _)
                match mode with
 	       | STABLE_MODE -> 
 		  ()
-	       | BREAKOUT_POINT (s', breakout_inv) when not(s#equal s') ->
+	       | BREAKOUT_POINT (s', _breakout_inv) when not(s#equal s') ->
 		  ()
 	       | BREAKOUT_POINT (s', breakout_inv) when s#equal s' ->
 		  breakout_inv := pre#join (!breakout_inv);

--- a/CodeHawk/CH/chlib/cHLinearEqualitiesDomainNoArrays.ml
+++ b/CodeHawk/CH/chlib/cHLinearEqualitiesDomainNoArrays.ml
@@ -40,6 +40,7 @@ open CHNumericalConstraints
 open CHPretty
 open CHUtils
 
+[@@@warning "-27"]
 
 exception Contradiction
 exception Got_integer of int
@@ -85,7 +86,7 @@ let reflect_trivial (vars: variable_t list) =
     matrix = Array.make 0 None
   }    
   
-let reflected_to_pretty rs =
+let _reflected_to_pretty rs =
   if rs.bottom then
     STR "_|_"
   else
@@ -517,11 +518,11 @@ object (self: 'a)
     object
       inherit domain_observer_t
             
-      method getObservedFactors = factors#toList
+      method! getObservedFactors = factors#toList
                                 
-      method getObservedVariables = List.map (fun f -> f#getVariable) factors#toList
+      method! getObservedVariables = List.map (fun f -> f#getVariable) factors#toList
                                   
-      method getNumericalConstraints ~(variables: variable_t list option) () =
+      method! getNumericalConstraints ~(variables: variable_t list option) () =
         let get_csts mat =
 	  Array.fold_right (fun c a -> match c with Some cst -> cst :: a | None -> a) mat []
         in

--- a/CodeHawk/CH/chlib/cHLocalIterationSigmaCombinator.ml
+++ b/CodeHawk/CH/chlib/cHLocalIterationSigmaCombinator.ml
@@ -74,7 +74,7 @@ end
 class virtual local_iteration_sigma_combinator_t
                 ~(domain_1: string)
                 ~(domain_2: string) =
-object (self: 'a)
+object (_self: 'a)
              
   inherit local_iteration_sigma_combinator_with_threshold_t
             ~domain_1:domain_1 ~domain_2:domain_2 ~threshold:(-1)

--- a/CodeHawk/CH/chlib/cHNonRelationalDatabase.ml
+++ b/CodeHawk/CH/chlib/cHNonRelationalDatabase.ml
@@ -32,7 +32,6 @@ open CHLanguage
 open CHNonRelationalDomainValues
 open CHNonRelationalTable   
 open CHPretty
-open CHSymbolicSets   
 open CHUtils
 
 
@@ -85,11 +84,11 @@ object (self: 'a)
     in
     {< tables = tables'' >}    
     
-  method meet (db: 'a) =
+  method meet (_db: 'a) =
     (* Databases are not subject to refinement because updates are conservative *)
     {< >}
     
-  method narrowing (db: 'a) =
+  method narrowing (_db: 'a) =
     (* Databases are not subject to refinement because updates are conservative *)
     {< >}
     
@@ -124,7 +123,7 @@ object (self: 'a)
   method analyzeQueryNoDB
            (cmd: (code_int, cfg_int) command_t): (variable_t * non_relational_domain_value_t) list =
     match cmd with
-    | SELECT {selected = selected; from = from; where = where} ->
+    | SELECT {selected = selected; from = _from; where = _where} ->
        List.map (fun (_, v) -> (v, topNonRelationalDomainValue)) selected
     | _ ->
        raise (CHFailure (STR "Database error #5"))
@@ -181,7 +180,7 @@ object (self: 'a)
 		 begin
 		   try
 		     let (k, _) =
-                       List.find (fun (k, (_, index)) ->
+                       List.find (fun (_k, (_, index)) ->
                            match index with
                            | PRIMARY_INDEX -> true
                            | _ -> false) s in

--- a/CodeHawk/CH/chlib/cHNonRelationalDomainBase.ml
+++ b/CodeHawk/CH/chlib/cHNonRelationalDomainBase.ml
@@ -26,7 +26,6 @@
   ============================================================================== *)
 
 (* chlib  *)
-open CHCommon
 open CHDomainObserver   
 open CHLanguage
 open CHNonRelationalDomainValues   

--- a/CodeHawk/CH/chlib/cHNonRelationalDomainExtensiveArrays.ml
+++ b/CodeHawk/CH/chlib/cHNonRelationalDomainExtensiveArrays.ml
@@ -29,7 +29,6 @@
 open CHCommon
 open CHCommunications   
 open CHConstants   
-open CHDomain
 open CHDomainObserver   
 open CHIntervals   
 open CHLanguage
@@ -40,6 +39,7 @@ open CHPretty
 open CHStridedIntervals
 open CHUtils
 
+[@@@warning "-27"]
 
 class virtual non_relational_domain_extensive_arrays_t
                 (do_precise_read_write: bool)
@@ -101,7 +101,7 @@ object (self: 'a)
   method private getExpansion v =
     match expand_all_arrays with
     | Some r -> r
-    | none ->
+    | None ->
        begin
 	 match expansions#get v with
 	 | None -> bottomInterval
@@ -132,18 +132,18 @@ object (self: 'a)
     object
       inherit domain_observer_t
             
-      method getObservedVariables = observer'#getObservedVariables
+      method! getObservedVariables = observer'#getObservedVariables
                                   
-      method getObservedArrays = arrays#listOfKeys
+      method! getObservedArrays = arrays#listOfKeys
                                
-      method getObservedArrayIndices a =
+      method! getObservedArrayIndices a =
         match arrays#get a with
 	| None -> []
 	| Some elts -> elts#listOfKeys
                      
-      method getNonRelationalVariableObserver = observer'#getNonRelationalVariableObserver
+      method !getNonRelationalVariableObserver = observer'#getNonRelationalVariableObserver
                                               
-      method getNonRelationalExtensiveArrayObserver a i =
+      method !getNonRelationalExtensiveArrayObserver a i =
         match arrays#get a with
 	| None ->
 	   topNonRelationalDomainValue
@@ -200,7 +200,7 @@ object (self: 'a)
 	else
 	  table'#remove v) vars
     
-  method private assign_array_elt table' arrays' a i x =
+  method private assign_array_elt _table' arrays' a i x =
     let expansion_r = self#getExpansion a in
     if expansion_r#isBottom then
       ()
@@ -246,7 +246,7 @@ object (self: 'a)
 	   else
 	     self#abstractElements arrays' a i_r
 	  
-  method private read_array_elt table' arrays' x a i =
+  method private read_array_elt table' _arrays' x a i =
     let expansion_r = self#getExpansion a in
     if expansion_r#isBottom then
       table'#remove x
@@ -282,7 +282,7 @@ object (self: 'a)
 	     | None -> table'#remove x
 	     | Some e -> self#setValue table' x e				      
                
-  method private abstract_elts arrays' expansions' a min max =
+  method private abstract_elts arrays' _expansions' a min max =
     let expansion_r = self#getExpansion a in
     if expansion_r#isBottom then
       ()
@@ -463,7 +463,7 @@ object (self: 'a)
        {< table = table'; arrays = arrays' >}
     | BLIT_ARRAYS (tgt, tgt_o, src, src_o, n) ->
        (self#analyzeFwd (BLIT_ARRAYS (src, src_o, tgt, tgt_o, n)))#analyzeFwd (ABSTRACT_VARS [tgt])
-    | SET_ARRAY_ELTS (a, s, n, _) ->
+    | SET_ARRAY_ELTS (a, _s, _n, _) ->
        (* The backward semantics of this operation can be modeled more precisely *)
        self#analyzeFwd (ABSTRACT_VARS [a])
     | SHIFT_ARRAY (tgt, src, n) ->

--- a/CodeHawk/CH/chlib/cHNonRelationalDomainNoArrays.ml
+++ b/CodeHawk/CH/chlib/cHNonRelationalDomainNoArrays.ml
@@ -28,16 +28,15 @@
 (* chlib *)
 open CHCommon
 open CHCommunications   
-open CHDomain   
 open CHLanguage
 open CHDomainObserver   
 open CHNonRelationalDomainBase   
 open CHNonRelationalDomainValues   
-open CHNumerical
 open CHNumericalConstraints   
 open CHPretty
 open CHUtils
 
+[@@@warning "-27"]
 
 class virtual non_relational_domain_t =
 object (self: 'a)
@@ -233,9 +232,9 @@ object (self: 'a)
     object
       inherit domain_observer_t
             
-      method getObservedVariables = table#listOfKeys
+      method! getObservedVariables = table#listOfKeys
                                   
-      method getNonRelationalVariableObserver = get_value
+      method! getNonRelationalVariableObserver = get_value
     end
     
   method observer = self#observer'

--- a/CodeHawk/CH/chlib/cHNonRelationalDomainValues.ml
+++ b/CodeHawk/CH/chlib/cHNonRelationalDomainValues.ml
@@ -373,13 +373,13 @@ object (self: 'a)
 		   v1#toPretty;
                    STR " and ";
                    v2#toPretty]))
-    | (NUM_CONSTANT_VAL v1, INTERVAL_VAL v2) -> self#join v
-    | (NUM_CONSTANT_VAL v1, STRIDED_INTERVAL_VAL v2) -> self#join v
+    | (NUM_CONSTANT_VAL _v1, INTERVAL_VAL _v2) -> self#join v
+    | (NUM_CONSTANT_VAL _v1, STRIDED_INTERVAL_VAL _v2) -> self#join v
     | (INTERVAL_VAL _, NUM_CONSTANT_VAL _) -> v#widening self
     | (STRIDED_INTERVAL_VAL _, NUM_CONSTANT_VAL _) -> v#widening self
     | (VALUESET_VAL v1, VALUESET_VAL v2) ->
        {< value = normalize_nr_value (VALUESET_VAL (v1#widening v2)) >}
-    | (SYM_CONSTANT_VAL v1, SYM_SET_VAL v2) -> self#join v
+    | (SYM_CONSTANT_VAL _v1, SYM_SET_VAL _v2) -> self#join v
     | (SYM_SET_VAL _, SYM_CONSTANT_VAL _) -> v#widening self
     | (_, _) -> {< value = TOP_VAL >}
 
@@ -480,11 +480,11 @@ object (self: 'a)
 		   v1#toPretty;
                    STR " and ";
                    v2#toPretty]))
-    | (NUM_CONSTANT_VAL v1, INTERVAL_VAL v2) -> self#meet v
-    | (NUM_CONSTANT_VAL v1, STRIDED_INTERVAL_VAL v2) -> self#meet v
+    | (NUM_CONSTANT_VAL _v1, INTERVAL_VAL _v2) -> self#meet v
+    | (NUM_CONSTANT_VAL _v1, STRIDED_INTERVAL_VAL _v2) -> self#meet v
     | (INTERVAL_VAL _, NUM_CONSTANT_VAL _) -> self#meet v
     | (STRIDED_INTERVAL_VAL _, NUM_CONSTANT_VAL _) -> self#meet v
-    | (SYM_CONSTANT_VAL v1, SYM_SET_VAL v2) -> self#meet v
+    | (SYM_CONSTANT_VAL _v1, SYM_SET_VAL _v2) -> self#meet v
     | (SYM_SET_VAL _, SYM_CONSTANT_VAL _) -> self#meet v
     | (_, _) -> {< value = BOTTOM_VAL >}
 

--- a/CodeHawk/CH/chlib/cHNonRelationalTable.ml
+++ b/CodeHawk/CH/chlib/cHNonRelationalTable.ml
@@ -27,18 +27,15 @@
 
 (* chlib *)
 open CHCommon
-open CHConstants   
-open CHDomain   
 open CHLanguage
 open CHNonRelationalDomainValues   
-open CHNumerical
 open CHPretty
 open CHSymbolicSets   
 open CHUtils
 
 
 class table_index_t (l: (string * symbol_t) list) =
-object (self: 'a)
+object (_self: 'a)
   
   val assoc_list = l
                  
@@ -75,7 +72,7 @@ object (self: 'a)
 end
   
 class table_row_t (r: (string * non_relational_domain_value_t) list) =
-object (self: 'a)
+object (_self: 'a)
      
   val row = r
           
@@ -261,7 +258,7 @@ object (self: 'a)
 end
   
 class non_relational_table_t (k: string) (s: nr_table_signature_t) =
-object (self: 'a)
+object (_self: 'a)
      
   val key: string = k
                   

--- a/CodeHawk/CH/chlib/cHNumericalConstantsDomainExtensiveArrays.ml
+++ b/CodeHawk/CH/chlib/cHNumericalConstantsDomainExtensiveArrays.ml
@@ -26,25 +26,17 @@
   ============================================================================== *)
 
 (* chlib *)
-open CHCommon
-open CHConstants   
-open CHDomain   
-open CHLanguage
 open CHNonRelationalDomainExtensiveArrays
-open CHNonRelationalDomainValues   
-open CHNumerical
 open CHNumericalConstantsDomainNoArrays   
-open CHPretty
-open CHUtils
 
 
 class numerical_constants_domain_extensive_arrays_t
         ?(do_precise_read_write = false)
         (index_domain: string) =
-object (self: 'a)
+object (_self: 'a)
 
   inherit numerical_constants_domain_no_arrays_t
-  inherit non_relational_domain_extensive_arrays_t do_precise_read_write index_domain
+  inherit! non_relational_domain_extensive_arrays_t do_precise_read_write index_domain
 
 end
     

--- a/CodeHawk/CH/chlib/cHNumericalConstantsDomainNoArrays.ml
+++ b/CodeHawk/CH/chlib/cHNumericalConstantsDomainNoArrays.ml
@@ -28,13 +28,10 @@
 (* chlib *)
 open CHCommon
 open CHConstants   
-open CHDomain   
 open CHLanguage
 open CHNonRelationalDomainNoArrays
 open CHNonRelationalDomainValues   
-open CHNumerical   
 open CHPretty
-open CHUtils
 
 
 class numerical_constants_domain_no_arrays_t =
@@ -51,7 +48,7 @@ object (self: 'a)
   method private setValue' t v x =
     self#setValue t v (new non_relational_domain_value_t (NUM_CONSTANT_VAL x))
     
-  method special cmd args = {< >}
+  method special _cmd _args = {< >}
                           
   method private importValue v =
     new non_relational_domain_value_t (NUM_CONSTANT_VAL (v#toNumericalConstant))
@@ -224,12 +221,12 @@ object (self: 'a)
 	     self#setValue' table' z z_c'';
 	     default()
 	   end	    
-      | ASSIGN_NUM (v, MULT (x, y)) ->
+      | ASSIGN_NUM (v, MULT (_x, _y)) ->
 	 begin
 	   table'#remove v;
 	   default ()
 	 end
-      | ASSIGN_NUM (v, DIV (x, y)) ->
+      | ASSIGN_NUM (v, DIV (_x, _y)) ->
 	 begin
 	   table'#remove v;
 	   default ()

--- a/CodeHawk/CH/chlib/cHOnlineCodeSet.ml
+++ b/CodeHawk/CH/chlib/cHOnlineCodeSet.ml
@@ -28,7 +28,6 @@
 (* chlib *)
 open CHCommon
 open CHLanguage   
-open CHNumerical   
 open CHPretty
 open CHUtils
 
@@ -36,7 +35,7 @@ class code_t
         (code_id: int) 
         ?(command_to_pretty=(CHLanguage.command_to_pretty 0))
         (l: ((code_int, cfg_int) command_t) list): code_int =
-object (self: _)
+object (_self: _)
      
   val id = code_id
          

--- a/CodeHawk/CH/chlib/cHPEPRBounds.ml
+++ b/CodeHawk/CH/chlib/cHPEPRBounds.ml
@@ -29,10 +29,8 @@
 
 (* chlib *)
 open CHCommon
-open CHIntervals
 open CHLanguage
 open CHNumerical
-open CHPEPRDictionary
 open CHPEPRTypes
 open CHPretty
 
@@ -162,7 +160,7 @@ object (self:'a)
         | [] ->
            raise (CHFailure (LBLOCK [ STR "Single coefficient index not found in: " ;
                                       self#toPretty ]))
-        | h::tl when h#equal numerical_one -> i
+        | h::_tl when h#equal numerical_one -> i
         | _::tl -> aux tl (i+1) in
       aux k 0
     else
@@ -279,13 +277,13 @@ object (self:'a)
 
   method neg = self#mkNew (List.map (fun x -> x#neg) s)
 
-  method add (a:'a) = self#mkNew (self#x_product (fun x x' -> x#add x') s)
+  method add (_a:'a) = self#mkNew (self#x_product (fun x x' -> x#add x') s)
 
   method sub (a:'a) = self#add a#neg
 
-  method mult (a:'a) = self#mkNew []
+  method mult (_a:'a) = self#mkNew []
 
-  method div (a:'a) = self#mkNew []
+  method div (_a:'a) = self#mkNew []
 
   method toPretty =
     LBLOCK [ pretty_print_list s (fun x -> x#toPretty) "[" "; " "]" ]
@@ -747,8 +745,8 @@ let mk_pex_pset (p:pex_set_int list) =
   let index = pd#index_pex_pset_data p in
   new pex_pset_t index p
 
-let zero_pex_pset_lb = mk_pex_pset [ zero_pex_set_lb ]
-let zero_pex_pset_ub = mk_pex_pset [ zero_pex_set_ub ]
+let _zero_pex_pset_lb = mk_pex_pset [ zero_pex_set_lb ]
+let _zero_pex_pset_ub = mk_pex_pset [ zero_pex_set_ub ]
 
 let mk_number_pex_pset_lb n = mk_pex_pset [ mk_number_pex_set_lb n ]
 let mk_number_pex_pset_ub n = mk_pex_pset [ mk_number_pex_set_ub n ]
@@ -759,7 +757,7 @@ let mk_parameter_pex_pset_lb index size =
 let mk_parameter_pex_pset_ub index size =
   mk_pex_pset [ mk_parameter_pex_set_ub index size ]
 
-let top_pex_pset = mk_pex_pset [ top_pex_set ]
+let _top_pex_pset = mk_pex_pset [ top_pex_set ]
 
 let normalize_pepr_bound (b:pepr_bounds_t) =
   match b with
@@ -838,7 +836,7 @@ object (self:'a)
       | (XTOP,_) | (_, XTOP) -> self#mkNew XTOP
       | (XPSET p, XPSET p') when p#is_number -> self#mkNew (XPSET (p'#mult p#get_number))
       | (XPSET p, XPSET p') when p'#is_number -> self#mkNew (XPSET (p#mult p'#get_number))
-      | (XPSET p, XPSET p') -> self#mkNew XTOP in
+      | (XPSET _p, XPSET _p') -> self#mkNew XTOP in
     let _ = trace_binary 2 "Bound#mult" self " mult " a r in
     r
 

--- a/CodeHawk/CH/chlib/cHPEPRBounds.mli
+++ b/CodeHawk/CH/chlib/cHPEPRBounds.mli
@@ -26,11 +26,9 @@
   ============================================================================== *)
 
 (* chlib *)
-open CHIntervals
 open CHLanguage
 open CHNumerical
 open CHPEPRTypes
-open CHPretty
 
 val mk_pepr_params: variable_t list -> pepr_params_int
 

--- a/CodeHawk/CH/chlib/cHPEPRDictionary.ml
+++ b/CodeHawk/CH/chlib/cHPEPRDictionary.ml
@@ -26,10 +26,8 @@
   ============================================================================== *)
 
 (* chlib *)
-open CHBounds
 open CHCommon
 open CHIndexedHTable
-open CHIntervals
 open CHNumerical
 open CHPEPRTypes
 open CHPretty

--- a/CodeHawk/CH/chlib/cHPEPRDomainNoArrays.ml
+++ b/CodeHawk/CH/chlib/cHPEPRDomainNoArrays.ml
@@ -33,7 +33,6 @@ open CHNonRelationalDomainNoArrays
 open CHNonRelationalDomainValues
 open CHNumerical
 open CHNumericalConstraints
-open CHPEPRBounds
 open CHPEPRange
 open CHPEPRTypes
 open CHPretty
@@ -127,7 +126,7 @@ object (self:'a)
         let r = self#getValue' v in
         pr_trace [ v#toPretty ; STR ": " ; r#toPretty ; NL ]) vars
 
-  method special cmd args = {< >}
+  method special _cmd _args = {< >}
 
   method private is_parameter (v:variable_t) = params#has_variable v
 
@@ -445,12 +444,12 @@ object (self:'a)
                self#setValue' table' z z_i'';
                default ()
              end
-        | ASSIGN_NUM (v, MULT (x, y)) ->
+        | ASSIGN_NUM (v, MULT (_x, _y)) ->
            begin
              table'#remove v ;
              default ()
            end
-        | ASSIGN_NUM (v, DIV (x, y)) ->
+        | ASSIGN_NUM (v, DIV (_x, _y)) ->
            begin
              table'#remove v ;
              default ()

--- a/CodeHawk/CH/chlib/cHPEPRDomainNoArrays.mli
+++ b/CodeHawk/CH/chlib/cHPEPRDomainNoArrays.mli
@@ -26,13 +26,10 @@
   ============================================================================== *)
 
 (* chlib *)
-open CHCommon
 open CHDomainObserver
 open CHLanguage
 open CHNonRelationalDomainValues
-open CHNumerical
 open CHNumericalConstraints
-open CHPEPRBounds
 open CHPEPRTypes
 open CHPretty
 

--- a/CodeHawk/CH/chlib/cHPEPRTypes.mli
+++ b/CodeHawk/CH/chlib/cHPEPRTypes.mli
@@ -26,7 +26,6 @@
   ------------------------------------------------------------------------------ *)
 
 (* chlib *)
-open CHBounds
 open CHIntervals
 open CHLanguage
 open CHNumerical

--- a/CodeHawk/CH/chlib/cHPEPRange.ml
+++ b/CodeHawk/CH/chlib/cHPEPRange.ml
@@ -368,13 +368,13 @@ object (self:'a)
     match v with
     | PEPRTOP -> xtop_pepr_bound
     | PEPRANGE r -> r#get_min
-    | PEPRDEP d -> raise (CHFailure (self#wrongtypeErrorMsg "get_min"))
+    | PEPRDEP _d -> raise (CHFailure (self#wrongtypeErrorMsg "get_min"))
 
   method get_max =
     match v with
     | PEPRTOP -> xtop_pepr_bound
     | PEPRANGE r -> r#get_max
-    | PEPRDEP d -> raise (CHFailure (self#wrongtypeErrorMsg "get_max"))
+    | PEPRDEP _d -> raise (CHFailure (self#wrongtypeErrorMsg "get_max"))
 
   method is_top = match v with PEPRTOP -> true | _ -> false
 
@@ -388,7 +388,7 @@ object (self:'a)
       match v with
       | PEPRTOP -> false
       | PEPRANGE r -> r#is_bounded
-      | PEPRDEP d -> raise (CHFailure (self#wrongtypeErrorMsg "is_bounded"))
+      | PEPRDEP _d -> raise (CHFailure (self#wrongtypeErrorMsg "is_bounded"))
 
   method equal (a:'a) =
     match (self#is_top, a#is_top) with

--- a/CodeHawk/CH/chlib/cHPolyhedra.ml
+++ b/CodeHawk/CH/chlib/cHPolyhedra.ml
@@ -762,7 +762,7 @@ object (self: 'a)
 	let nbrows = ref 0 in
 	let _ =
 	  match (!(pa#c), !(pa#f), !(pb#c), !(pb#f)) with
-	  | (Some pa_c, Some pa_f, Some pb_c, Some pb_f) ->		
+	  | (Some _pa_c, Some pa_f, Some pb_c, Some _pb_f) ->		
 	     let npoly_c = new matrix_t ((!pGD)#dec - 1 + pb_c#nbrows) pb_c#nbcolumns false in
 	     let _ = npoly#set_c npoly_c in
 	     begin

--- a/CodeHawk/CH/chlib/cHPolyhedraDomainNoArrays.ml
+++ b/CodeHawk/CH/chlib/cHPolyhedraDomainNoArrays.ml
@@ -31,7 +31,6 @@
 open CHCommon
 open CHCommunications
 open CHConstants   
-open CHDomain
 open CHDomainObserver
 open CHIntervals   
 open CHLanguage   
@@ -45,6 +44,7 @@ open CHPretty
 open CHVector
 open CHUtils
 
+[@@@warning "-27"]
 
 let dummy_variable = new variable_t (new symbol_t "<#dummy#>") NUM_VAR_TYPE
 let dummy_factor = new numerical_factor_t dummy_variable
@@ -283,18 +283,18 @@ object (self: 'a)
     object
       inherit domain_observer_t
             
-      method getObservedVariables = var2index#keys#toList
+      method! getObservedVariables = var2index#keys#toList
                                   
-      method getPolyhedron =
+      method! getPolyhedron =
         if self#isBottom then
 	  None
         else
 	  Some polyhedron
 	
-      method getNonRelationalVariableObserver v =
+      method! getNonRelationalVariableObserver v =
         self#getNonRelationalValue v
 	
-      method getNumericalConstraints ~(variables: variable_t list option) () =
+      method! getNumericalConstraints ~(variables: variable_t list option) () =
         if self#isBottom then
 	  []
         else
@@ -310,7 +310,7 @@ object (self: 'a)
 	     let self_r' = self#remove_variables_r self_r variables_to_remove#toList in
 	     (self#reify self_r')#observer#getNumericalConstraints ~variables:None ()
              
-      method getVariableOrdering = Some index2var
+      method! getVariableOrdering = Some index2var
     end
     
   method private arrangeVariables (vars: VariableCollections.set_t) =

--- a/CodeHawk/CH/chlib/cHPretty.ml
+++ b/CodeHawk/CH/chlib/cHPretty.ml
@@ -55,7 +55,7 @@ object
     
   method print p =    
     let prTabs t =
-      for i = 0 to t - 1 do
+      for _i = 0 to t - 1 do
 	output_string out " "	
       done
     in

--- a/CodeHawk/CH/chlib/cHSCC.ml
+++ b/CodeHawk/CH/chlib/cHSCC.ml
@@ -27,8 +27,6 @@
 
 (* chlib *)
 open CHBounds
-open CHCollections   
-open CHCommon
 open CHLanguage
 open CHNumerical   
 open CHPretty

--- a/CodeHawk/CH/chlib/cHSaturationMatrix.ml
+++ b/CodeHawk/CH/chlib/cHSaturationMatrix.ml
@@ -28,8 +28,6 @@
 (* chlib *)
 open CHBitstring
 open CHCommon
-open CHNumerical   
-open CHPretty
 
 
 class satmat_t nr nc =

--- a/CodeHawk/CH/chlib/cHStateSetsDomainNoArrays.ml
+++ b/CodeHawk/CH/chlib/cHStateSetsDomainNoArrays.ml
@@ -27,12 +27,9 @@
 
 (* chlib *)
 open CHCommon
-open CHConstants   
-open CHDomain   
 open CHLanguage
 open CHNonRelationalDomainNoArrays
 open CHNonRelationalDomainValues   
-open CHNumerical   
 open CHPretty
 open CHSymbolicSets
 open CHUtils
@@ -43,6 +40,8 @@ module H = Hashtbl
 (* policy: policy-name, transitions
    transition: transition       -name, (pre,post) list
  *)
+
+[@@@warning "-27"]
          
 class state_sets_domain_no_arrays_t
         (policies:(string * (string * (symbol_t * symbol_t) list) list) list) = 
@@ -78,7 +77,7 @@ object (self: 'a)
   method private setValue' t v x =
     self#setValue t v (new non_relational_domain_value_t (SYM_SET_VAL x))
     
-  method special cmd args = {< >}
+  method special _cmd _args = {< >}
                           
   method private importValue v =
     new non_relational_domain_value_t (SYM_SET_VAL (v#toSymbolicSet))
@@ -207,8 +206,8 @@ object (self: 'a)
     else
       raise (CHFailure (LBLOCK [ STR "Policy " ; STR name ; STR " not found" ]))
     
-  method analyzeOperation ~(domain_name:string) ~(fwd_direction:bool)
-                          ~(operation:operation_t):'a =
+  method! analyzeOperation ~(domain_name:string) ~(fwd_direction:bool)
+                           ~(operation:operation_t):'a =
     let name = operation.op_name#getBaseName in
     let policyname = List.hd operation.op_name#getAttributes in
     let transitiontable = self#get_transition_table policyname in
@@ -225,7 +224,7 @@ object (self: 'a)
        if H.mem transitiontable name then
          let preposts = H.find transitiontable name in
          begin
-           List.iter (fun (sym,v,_) ->
+           List.iter (fun (_sym,v,_) ->
                if fwd_direction then
                  let states = self#getValue' v in
                  if states#isTop || states#isBottom then

--- a/CodeHawk/CH/chlib/cHStaticChecker.ml
+++ b/CodeHawk/CH/chlib/cHStaticChecker.ml
@@ -28,7 +28,6 @@
 (* chlib *)
 open CHCommon
 open CHLanguage
-open CHNumerical
 open CHPretty
 open CHUtils
 
@@ -62,7 +61,7 @@ object (self: _)
   method private hasVariable (varList : CHUtils.VariableCollections.set_t) searchVar =
     let rec findVarInType searchPath (searchVarIn : variable_t) =
       match searchVarIn#getType with
-      | STRUCT_TYPE st ->
+      | STRUCT_TYPE _st ->
          (match searchPath with 
           | [name] -> (searchVarIn#field name)#equal searchVar
           | first :: last -> findVarInType last (searchVarIn#field first)
@@ -72,7 +71,7 @@ object (self: _)
     if varList#has searchVar then true else
       varList#fold (fun myBool myVar -> myBool || (findVarInType (searchVar#getPath) myVar)) false
     
-  method walkVar v =
+  method! walkVar v =
     let err () =
       self#error [STR "Variable "; v#toPretty; STR " is undefined"]
     in
@@ -103,7 +102,7 @@ object (self: _)
        else
 	 err ()
       
-  method walkNumExp e =
+  method! walkNumExp e =
     let error v =
       self#error [STR "Variable "; v#toPretty; STR " used in numerical expression"]
     in
@@ -127,7 +126,7 @@ object (self: _)
     in
     super#walkNumExp e
     
-  method walkSymExp e =
+  method! walkSymExp e =
     let _ = match e with
       | SYM_VAR v ->
 	 if v#isSymbolic && not(v#isArray) then
@@ -139,7 +138,7 @@ object (self: _)
     in
     super#walkSymExp e
     
-  method walkBoolExp e =
+  method! walkBoolExp e =
     let _ = match e with
       | LEQ (x, y)
         | GEQ (x, y)
@@ -166,13 +165,13 @@ object (self: _)
     in
     super#walkBoolExp e
     
-  method walkCmd cmd =
+  method! walkCmd cmd =
     match cmd with
     | TRANSACTION (_, code, post_code) ->
        let checker = object
 	   inherit code_walker_t
 	         
-	   method walkCmd cmd =
+	   method! walkCmd cmd =
 	     match cmd with
 	     | LOOP _
 	       | CFG _ ->

--- a/CodeHawk/CH/chlib/cHStaticInliner.ml
+++ b/CodeHawk/CH/chlib/cHStaticInliner.ml
@@ -30,7 +30,6 @@ open CHCommon
 open CHLanguage   
 open CHNumerical
 open CHPretty
-open CHStack
 open CHUtils
 
 module Make (F: LANGUAGE_FACTORY) =
@@ -67,7 +66,7 @@ module Make (F: LANGUAGE_FACTORY) =
 	   | Some d -> d#lt depth
 	   | None -> true
                    
-      method transformCmd cmd =
+      method! transformCmd cmd =
         match cmd with
 	| CONTEXT (s, code) ->
 	   let processor' = {< context = s :: context >} in
@@ -176,7 +175,7 @@ module Make (F: LANGUAGE_FACTORY) =
             ?(op_proc: op_processor_t option)
             ?(exclusions: (symbol_t -> bool) option)
             (sys: system_int) =
-    object (self: _)
+    object (_self: _)
          
       val system = sys
                  

--- a/CodeHawk/CH/chlib/cHStaticInliner.mli
+++ b/CodeHawk/CH/chlib/cHStaticInliner.mli
@@ -25,8 +25,9 @@
    SOFTWARE.
   ------------------------------------------------------------------------------ *)
 
+[@@@warning "-67"]
 module Make :
-functor (F : CHLanguage.LANGUAGE_FACTORY) ->
+functor (F: CHLanguage.LANGUAGE_FACTORY) ->
 sig
   class inlining_processor_t :
           int ->

--- a/CodeHawk/CH/chlib/cHStridedGaussSeidelSigmaCombinator.ml
+++ b/CodeHawk/CH/chlib/cHStridedGaussSeidelSigmaCombinator.ml
@@ -26,12 +26,10 @@
   ============================================================================== *)
 
 (* chlib *)
-open CHCommon
 open CHConstants   
 open CHLocalIterationSigmaCombinator
 open CHNonRelationalDomainValues
 open CHNumericalConstraints   
-open CHPretty   
 open CHStridedIntervals
 
 exception Bottom_found

--- a/CodeHawk/CH/chlib/cHStridedIntervals.ml
+++ b/CodeHawk/CH/chlib/cHStridedIntervals.ml
@@ -68,7 +68,7 @@ let adjustStride (mn: bound_t) (mx: bound_t) (st: numerical_t) : numerical_t =
   if (mx#leq mn) then numerical_one else st
   
 (* assumes mn, mx are reachable with the stride; ensures rem < stride *)
-let adjustRem (mn: bound_t) (mx: bound_t) (st: numerical_t) (rm: numerical_t) : numerical_t =                                     
+let adjustRem (_mn: bound_t) (_mx: bound_t) (st: numerical_t) (rm: numerical_t) : numerical_t =                                     
   if (st#equal numerical_one) then numerical_zero else rm#modulo st
   
   
@@ -196,11 +196,11 @@ object (self : 'a)
   method isBoundInInterval (b: bound_t) : bool = 
     match (min#getBound, max#getBound, b#getBound) with
     | (NUMBER mn, NUMBER mx, NUMBER x) -> (x#geq mn) && (x#leq mx)
-    | (NUMBER mn, NUMBER mx, _) -> false
+    | (NUMBER _mn, NUMBER _mx, _) -> false
     | (NUMBER mn, PLUS_INF, NUMBER x) -> x#geq mn
-    | (NUMBER mn, PLUS_INF, PLUS_INF) -> true
+    | (NUMBER _mn, PLUS_INF, PLUS_INF) -> true
     | (MINUS_INF, NUMBER mx, NUMBER x) -> x#leq mx
-    | (MINUS_INF, NUMBER mx, MINUS_INF) -> true
+    | (MINUS_INF, NUMBER _mx, MINUS_INF) -> true
     | (MINUS_INF, PLUS_INF, _) -> true
     | (_,_,_) -> false
                

--- a/CodeHawk/CH/chlib/cHStridedIntervalsDomainExtensiveArrays.ml
+++ b/CodeHawk/CH/chlib/cHStridedIntervalsDomainExtensiveArrays.ml
@@ -26,16 +26,15 @@
   ============================================================================== *)
 
 (* chlib *)
-open CHDomain
 open CHNonRelationalDomainExtensiveArrays
 open CHStridedIntervalsDomainNoArrays
 
 class strided_intervals_domain_extensive_arrays_t
         ?(do_precise_read_write = false)
         (index_domain: string) =
-object (self: 'a)
+object (_self: 'a)
 
   inherit strided_intervals_domain_no_arrays_t
-  inherit non_relational_domain_extensive_arrays_t do_precise_read_write index_domain
+  inherit! non_relational_domain_extensive_arrays_t do_precise_read_write index_domain
     
 end

--- a/CodeHawk/CH/chlib/cHStridedIntervalsDomainNoArrays.ml
+++ b/CodeHawk/CH/chlib/cHStridedIntervalsDomainNoArrays.ml
@@ -27,12 +27,9 @@
 
 (* chlib *)
 open CHCommon
-open CHConstants   
-open CHDomain   
 open CHLanguage
 open CHNonRelationalDomainNoArrays
 open CHNonRelationalDomainValues   
-open CHNumerical   
 open CHPretty
 open CHStridedIntervals
 open CHUtils
@@ -54,7 +51,7 @@ object (self: 'a)
                    (v: variable_t) (x: strided_interval_t) =
     self#setValue t v (new non_relational_domain_value_t (STRIDED_INTERVAL_VAL x))
     
-  method special (cmd: string) (args: domain_cmd_arg_t list) : 'a = {< >}
+  method special (_cmd: string) (_args: domain_cmd_arg_t list) : 'a = {< >}
                                                                   
   method private importValue v =
     new non_relational_domain_value_t
@@ -242,12 +239,12 @@ object (self: 'a)
 	     self#setValue' table' z z_i'';
 	     default()
 	   end	    
-      | ASSIGN_NUM (v, MULT (x, y)) ->
+      | ASSIGN_NUM (v, MULT (_x, _y)) ->
 	 begin
 	   table'#remove v;
 	   default ()
 	 end
-      | ASSIGN_NUM (v, DIV (x, y)) ->
+      | ASSIGN_NUM (v, DIV (_x, _y)) ->
 	 begin
 	   table'#remove v;
 	   default ()

--- a/CodeHawk/CH/chlib/cHSymbolicConstantsDomainExtensiveArrays.ml
+++ b/CodeHawk/CH/chlib/cHSymbolicConstantsDomainExtensiveArrays.ml
@@ -26,16 +26,15 @@
   ============================================================================== *)
 
 (* chlib *)
-open CHDomain
 open CHNonRelationalDomainExtensiveArrays
 open CHSymbolicConstantsDomainNoArrays
 
 class symbolic_constants_domain_extensive_arrays_t
         ?(do_precise_read_write = false)
         (index_domain: string) =
-object (self: 'a)
+object (_self: 'a)
   
   inherit symbolic_constants_domain_no_arrays_t
-  inherit non_relational_domain_extensive_arrays_t do_precise_read_write index_domain
+  inherit! non_relational_domain_extensive_arrays_t do_precise_read_write index_domain
     
 end

--- a/CodeHawk/CH/chlib/cHSymbolicConstantsDomainNoArrays.ml
+++ b/CodeHawk/CH/chlib/cHSymbolicConstantsDomainNoArrays.ml
@@ -28,14 +28,11 @@
 (* chlib *)
 open CHCommon
 open CHConstants   
-open CHDomain   
 open CHLanguage
 open CHNonRelationalDomainNoArrays
 open CHNonRelationalDomainValues   
-open CHNumerical
 open CHNumericalConstraints   
 open CHPretty
-open CHUtils
 
 
 class symbolic_constants_domain_no_arrays_t =
@@ -52,12 +49,12 @@ object (self: 'a)
   method private setValue' t v x =
     self#setValue t v (new non_relational_domain_value_t (SYM_CONSTANT_VAL x))
     
-  method special cmd args = {< >}
+  method special _cmd _args = {< >}
                           
   method private importValue v =
     new non_relational_domain_value_t (NUM_CONSTANT_VAL (v#toNumericalConstant))
     
-  method importNumericalConstraints (csts: numerical_constraint_t list) = {< >}
+  method! importNumericalConstraints (_csts: numerical_constraint_t list) = {< >}
                                                                         
   method private analyzeFwd' (cmd: (code_int, cfg_int) command_t) =
     if bottom then

--- a/CodeHawk/CH/chlib/cHSymbolicSetsDomainExtensiveArrays.ml
+++ b/CodeHawk/CH/chlib/cHSymbolicSetsDomainExtensiveArrays.ml
@@ -26,16 +26,15 @@
   ============================================================================== *)
 
 (* chlib  *)
-open CHDomain
 open CHNonRelationalDomainExtensiveArrays
 open CHSymbolicSetsDomainNoArrays
 
 class symbolic_sets_domain_extensive_arrays_t
         ?(do_precise_read_write = false)
         (index_domain: string) =
-object (self: 'a)
+object (_self: 'a)
   
   inherit symbolic_sets_domain_no_arrays_t
-  inherit non_relational_domain_extensive_arrays_t do_precise_read_write index_domain
+  inherit! non_relational_domain_extensive_arrays_t do_precise_read_write index_domain
     
 end

--- a/CodeHawk/CH/chlib/cHSymbolicSetsDomainNoArrays.ml
+++ b/CodeHawk/CH/chlib/cHSymbolicSetsDomainNoArrays.ml
@@ -29,15 +29,11 @@
 
 (* chlib *)
 open CHCommon
-open CHConstants   
-open CHDomain   
 open CHLanguage
 open CHNonRelationalDomainNoArrays
 open CHNonRelationalDomainValues   
-open CHNumerical   
 open CHPretty
 open CHSymbolicSets
-open CHUtils
 
    
 class symbolic_sets_domain_no_arrays_t = 
@@ -62,7 +58,7 @@ object (self: 'a)
   method private setValue' t v x =
     self#setValue t v (new non_relational_domain_value_t (SYM_SET_VAL x))
     
-  method special cmd args = {< >}
+  method special _cmd _args = {< >}
                           
   method private importValue v =
     new non_relational_domain_value_t (SYM_SET_VAL (v#toSymbolicSet))

--- a/CodeHawk/CH/chlib/cHSymbolicTypeRefinement.ml
+++ b/CodeHawk/CH/chlib/cHSymbolicTypeRefinement.ml
@@ -26,9 +26,7 @@
   ------------------------------------------------------------------------------ *)
 
 (* chlib *)
-open CHCommon
 open CHLanguage   
-open CHPretty
 
    
 module UF =
@@ -51,12 +49,12 @@ object (self: _)
                
   method virtual refineSymbolicType: 'a -> variable_type_t
                
-  method walkCmd (cmd: (code_int, cfg_int) command_t) =
+  method! walkCmd (cmd: (code_int, cfg_int) command_t) =
     match cmd with
     | ASSIGN_SYM (x, e) ->
        begin
 	 match e with
-	 | SYM s -> self#abstract x
+	 | SYM _s -> self#abstract x
 	 | SYM_VAR y -> 
 	    begin
 	      self#union x y;

--- a/CodeHawk/CH/chlib/cHTimedSymbolicSetsDomainNoArrays.ml
+++ b/CodeHawk/CH/chlib/cHTimedSymbolicSetsDomainNoArrays.ml
@@ -27,26 +27,19 @@
 
 (* chlib  *)
 open CHCommon
-open CHConstants   
-open CHDomain   
 open CHLanguage
-open CHNonRelationalDomainNoArrays
-open CHNonRelationalDomainValues   
-open CHNumerical   
-open CHPretty
 open CHSymbolicSetsDomainNoArrays
-open CHUtils
 
 
    
 class timed_symbolic_sets_domain_no_arrays_t (timeout:float) = 
-object (self: 'a)
+object (_self: 'a)
      
   inherit symbolic_sets_domain_no_arrays_t as super
         
   val starttime = Unix.gettimeofday ()
                 
-  method private analyzeFwd' (cmd:(code_int, cfg_int) command_t) =
+  method! private analyzeFwd' (cmd:(code_int, cfg_int) command_t) =
     let _ =
       if ((Unix.gettimeofday ()) -. starttime) > timeout then
         raise (CHTimeOut "symbolic sets") in

--- a/CodeHawk/CH/chlib/cHUnionFind.ml
+++ b/CodeHawk/CH/chlib/cHUnionFind.ml
@@ -125,7 +125,7 @@ struct
 	
     method get (x: E.t) = attribute_table#get (self#find x)
 
-    method union (x: E.t) (y: E.t) =
+    method! union (x: E.t) (y: E.t) =
       let e_x = self#find x in
       let e_y = self#find y in
       let att = match (attribute_table#get e_x, attribute_table#get e_y) with
@@ -143,7 +143,7 @@ struct
 	  | Some a -> attribute_table#set (self#find x) a
       end
 	
-    method reset =
+    method! reset =
       super#reset;
       attribute_table <- new C.simple_table_t
 	

--- a/CodeHawk/CH/chlib/cHUtils.ml
+++ b/CodeHawk/CH/chlib/cHUtils.ml
@@ -28,7 +28,6 @@
   ------------------------------------------------------------------------------ *)
 
 (* chlib *)
-open CHCommon
 open CHLanguage
 open CHNumerical   
 open CHPretty

--- a/CodeHawk/CH/chlib/cHValueSets.ml
+++ b/CodeHawk/CH/chlib/cHValueSets.ml
@@ -32,7 +32,7 @@ open CHLanguage
 open CHNumerical   
 open CHPretty
 
-let pr_debug_vs (p:pretty_t list) = ()
+let pr_debug_vs (_p:pretty_t list) = ()
 
 type base_offset_t = symbol_t * interval_t
 type base_offset_null_t = symbol_t * interval_t * bool

--- a/CodeHawk/CH/chlib/cHValueSetsDomainNoArrays.ml
+++ b/CodeHawk/CH/chlib/cHValueSetsDomainNoArrays.ml
@@ -34,8 +34,9 @@ open CHNumerical
 open CHPretty
 open CHValueSets
 
+[@@@warning "-27"]
 
-let pr_debug_vs p = ()
+let pr_debug_vs _p = ()
 let command_to_pretty = CHLanguage.command_to_pretty 0
                       
 class valueset_domain_no_arrays_t =
@@ -62,7 +63,7 @@ object (self: 'a)
   method private setValue' t v x =
     self#setValue t v (new non_relational_domain_value_t (VALUESET_VAL x))
 
-  method special cmd args = {< >}
+  method special _cmd _args = {< >}
 
   method private importValue v = 
     new non_relational_domain_value_t (VALUESET_VAL (v#toValueSet))
@@ -369,8 +370,8 @@ object (self: 'a)
       | _ ->
 	 default ()
 	
-  method analyzeOperation ~(domain_name:string) ~(fwd_direction:bool) 
-                          ~(operation:operation_t):'a =
+  method! analyzeOperation ~(domain_name:string) ~(fwd_direction:bool) 
+                           ~(operation:operation_t):'a =
     let name = operation.op_name#getBaseName in
     let table' = table#clone in
     let default () = {< table = table' >} in

--- a/CodeHawk/CH/chlib/cHVector.ml
+++ b/CodeHawk/CH/chlib/cHVector.ml
@@ -223,7 +223,7 @@ object (self: 'a)
     in
       !res
 
-  method permute_remove_dimensions (newq: vector_t) (dimsup: int) (permut: int array) =
+  method permute_remove_dimensions (newq: vector_t) (_dimsup: int) (permut: int array) =
     let q = self in
       begin
 	for j = 0 to (!pGD)#dec - 1 do

--- a/CodeHawk/CH/chlib/dune
+++ b/CodeHawk/CH/chlib/dune
@@ -3,7 +3,3 @@
   (libraries str unix zarith)
   (public_name codehawk.chlib)
   (wrapped false))
-
-(env
-  (dev
-    (flags (:standard -warn-error -A))))


### PR DESCRIPTION
Tested on ocaml 4.12.1, 4.13.1, 4.14.1, 5.0.0, 5.1.1

Developed by removing the "make warnings non-fatal" block from CH/chlib/dune, then running

```bash
$ CLICOLOR_FORCE=1 dune build 2>&1 | (head -n 50; echo; echo; echo; echo; wc -l)
```