### PR TITLE
Use `ocamldep` in `Makefile`s

### DIFF
--- a/CodeHawk/.gitignore
+++ b/CodeHawk/.gitignore
@@ -2,3 +2,4 @@ _bin
 _docs_public
 _docs_private
 _odoc
+.depend

--- a/CodeHawk/CH/chlib/Makefile
+++ b/CodeHawk/CH/chlib/Makefile
@@ -3,6 +3,7 @@ ZARITHLIB = $(shell ocamlfind query zarith)
 CAMLC := ocamlopt -I $(ZARITHLIB) -I str -I +unix -I cmi -I cmx 
 CAMLLINK := ocamlopt
 CAMLDOC := ocamldoc
+OCAMLDEP := ocamldep
 
 MLIS := \
 	cHPretty \
@@ -149,20 +150,20 @@ SOURCES := \
 
 OBJECTS := $(addprefix cmx/,$(SOURCES:%=%.cmx))
 
-all: make_dirs chlib.cmxa
+all: chlib.cmxa
 
 make_dirs:
 	@mkdir -p cmx
 	@mkdir -p cmi
 
-cmi/%.cmi: %.mli
+cmi/%.cmi: %.mli make_dirs 
 	$(CAMLC) -o $@ -c -opaque $<
 
-cmx/%.cmx: %.ml
+cmx/%.cmx: %.ml make_dirs 
 	$(CAMLC) -o $@ -c $<
 
 chlib.cmxa: $(CMIS) $(OBJECTS)
-	$(CAMLLINK) -a -o chlib.cmxa $(OBJECTS)
+	$(CAMLLINK) -a -o $@ $(OBJECTS)
 
 doc: $(OBJECTS)
 	rm -rf doc
@@ -170,6 +171,7 @@ doc: $(OBJECTS)
 	$(CAMLDOC) -html -d doc -v -stars -html -I . $(OBJECTS)
 
 clean:
+	rm -f .depend
 	rm -f */*.cmx
 	rm -f */*.cmi
 	rm -f */*.o
@@ -178,3 +180,10 @@ clean:
 	rm -f *.cmxa
 	rm -f Makefile~
 	rm -rf doc
+
+.depend:
+	$(OCAMLDEP) *.mli *.ml | sed "s|[^\t ]\+\.cmx|cmx/\0|" | sed "s|[^\t ]\+\.cmi|cmi/\0|" > .depend
+
+include .depend
+
+.PHONY: all make_dirs doc clean

--- a/CodeHawk/CH/chutil/Makefile
+++ b/CodeHawk/CH/chutil/Makefile
@@ -9,6 +9,7 @@ CAMLC := ocamlopt -I +unix -I cmi -I cmx \
 
 CAMLLINK := ocamlopt 
 CAMLDOC := ocamldoc
+OCAMLDEP := ocamldep
 
 MLIS := \
 	cHTraceResult \
@@ -70,19 +71,19 @@ SOURCES := \
 
 OBJECTS := $(addprefix cmx/,$(SOURCES:%=%.cmx))
 
-all: make_dirs chutil.cmxa
+all: chutil.cmxa
 
 make_dirs:
 	@mkdir -p cmx
 	@mkdir -p cmi
 
 chutil.cmxa: $(CMIS) $(OBJECTS) $(CHLIB)/chlib.cmxa  $(EXTLIB)/extlib.cmxa $(ZARITHLIB)/zarith.cmxa
-	$(CAMLLINK) -a -o chutil.cmxa  $(OBJECTS)
+	$(CAMLLINK) -a -o $@ $(OBJECTS)
 
-cmi/%.cmi: %.mli
+cmi/%.cmi: %.mli make_dirs
 	$(CAMLC) -o $@ -c -opaque $<
 
-cmx/%.cmx: %.ml
+cmx/%.cmx: %.ml make_dirs
 	$(CAMLC) -o $@ -c $<
 
 
@@ -95,6 +96,7 @@ doc: $(OBJECTS)
 	$(CAMLDOC) -html -d doc -v -stars -html -I . -I ../chlib $(OBJECTS)
 
 clean:
+	rm -f .depend
 	rm -f */*.cmx
 	rm -f */*.cmi
 	rm -f */*.o
@@ -104,3 +106,9 @@ clean:
 	rm -f Makefile~
 	rm -rf doc
 
+.depend:
+	$(OCAMLDEP) *.mli *.ml | sed "s|[^\t ]\+\.cmx|cmx/\0|" | sed "s|[^\t ]\+\.cmi|cmi/\0|" > .depend
+
+include .depend
+
+.PHONY: all make_dirs doc clean

--- a/CodeHawk/CH/xprlib/Makefile
+++ b/CodeHawk/CH/xprlib/Makefile
@@ -11,6 +11,7 @@ CAMLC := ocamlopt -I cmx -I cmi \
 
 CAMLLINK := ocamlopt
 CAMLDOC := ocamldoc
+OCAMLDEP := ocamldep
 
 MLIS := \
 	xprTypes \
@@ -39,19 +40,19 @@ SOURCES := \
 
 OBJECTS := $(addprefix cmx/,$(SOURCES:%=%.cmx))
 
-all: make_dirs xpr
+all: xpr.cmxa
 
 make_dirs:
 	@mkdir -p cmx
 	@mkdir -p cmi
 
-xpr: $(CMIS) $(OBJECTS) $(CHLIB)/chlib.cmxa $(CHUTIL.cmxa) $(ZARITHLIB)/zarith.cmxa
-	$(CAMLLINK) -a -o xpr.cmxa  $(OBJECTS)
+xpr.cmxa: $(CMIS) $(OBJECTS) $(CHLIB)/chlib.cmxa $(CHUTIL.cmxa) $(ZARITHLIB)/zarith.cmxa
+	$(CAMLLINK) -a -o $@ $(OBJECTS)
 
-cmi/%.cmi: %.mli
+cmi/%.cmi: %.mli make_dirs
 	$(CAMLC) -o $@ -c -opaque $<
 
-cmx/%.cmx: %.ml
+cmx/%.cmx: %.ml make_dirs
 	$(CAMLC) -o $@ -c $<
 
 doc: $(OBJECTS)
@@ -60,6 +61,7 @@ doc: $(OBJECTS)
 	$(CAMLDOC) -html -d doc -v -stars -html -I . -I $(CHUTIL) $(OBJECTS)
 
 clean:
+	rm -f .depend
 	rm -f */*.cmx
 	rm -f */*.cmi
 	rm -f */*.o
@@ -69,4 +71,9 @@ clean:
 	rm -f Makefile~
 	rm -rf doc
 
+.depend:
+	$(OCAMLDEP) *.mli *.ml | sed "s|[^\t ]\+\.cmx|cmx/\0|" | sed "s|[^\t ]\+\.cmi|cmi/\0|" > .depend
 
+include .depend
+
+.PHONY: all make_dirs doc clean

--- a/CodeHawk/CHB/bchanalyze/Makefile
+++ b/CodeHawk/CHB/bchanalyze/Makefile
@@ -31,7 +31,8 @@ CAMLC := ocamlopt  -I str -I cmi -I cmx \
 	-I $(ARMLIB)/cmi \
 	-I $(PWRLIB)/cmi \
 
-CAMLLINK := ocamlopt \
+CAMLLINK := ocamlopt
+OCAMLDEP := ocamldep
 
 MLIS := \
 	bCHAnalysisTypes \
@@ -68,22 +69,23 @@ SOURCES := \
 
 OBJECTS := $(addprefix cmx/,$(SOURCES:%=%.cmx))
 
-all: make_dirs bchanalyze
+all: bchanalyze.cmxa
 
 make_dirs:
 	@mkdir -p cmx
 	@mkdir -p cmi
 
-bchanalyze: $(OBJECTS) $(CMIS) $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(BCHLIB)/bchlib.cmxa $(PELIB)/bchlibpe.cmxa $(ELFLIB)/bchlibelf.cmxa $(X86LIB)/bchlibx86.cmxa $(MIPSLIB)/bchlibmips32.cmxa $(ARMLIB)/bchlibarm32.cmxa $(PWRLIB)/bchlibpower32.cmxa
-	$(CAMLLINK) -a -o bchanalyze.cmxa $(OBJECTS)
+bchanalyze.cmxa: $(OBJECTS) $(CMIS) $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(BCHLIB)/bchlib.cmxa $(PELIB)/bchlibpe.cmxa $(ELFLIB)/bchlibelf.cmxa $(X86LIB)/bchlibx86.cmxa $(MIPSLIB)/bchlibmips32.cmxa $(ARMLIB)/bchlibarm32.cmxa $(PWRLIB)/bchlibpower32.cmxa
+	$(CAMLLINK) -a -o $@ $(OBJECTS)
 
-cmi/%.cmi: %.mli
+cmi/%.cmi: %.mli make_dirs
 	$(CAMLC) -o $@ -c -opaque $<
 
-cmx/%.cmx: %.ml $(CMIS)
+cmx/%.cmx: %.ml make_dirs
 	$(CAMLC) -o $@ -c $<
 
 clean:
+	rm -f .depend
 	rm -f cmx/*.cm*
 	rm -f cmi/*.cmi
 	rm -f cmx/*.o
@@ -93,3 +95,10 @@ clean:
 	rm -f *.mli~
 	rm -f Makefile~ 
 	rm -rf doc
+
+.depend:
+	$(OCAMLDEP) *.mli *.ml | sed "s|[^\t ]\+\.cmx|cmx/\0|" | sed "s|[^\t ]\+\.cmi|cmi/\0|" > .depend
+
+include .depend
+
+.PHONY: all make_dirs doc clean

--- a/CodeHawk/CHB/bchcil/Makefile
+++ b/CodeHawk/CHB/bchcil/Makefile
@@ -33,6 +33,8 @@ CAMLLINK := ocamlopt \
 	$(XPRLIB)/xpr.cmxa \
 	$(BCHLIB)/bchlib.cmxa \
 
+OCAMLDEP := ocamldep
+
 CAMLLINKL := ocamlopt
 
 MLIS := \
@@ -51,26 +53,27 @@ SOURCES := \
 
 OBJECTS := $(addprefix cmx/,$(SOURCES:%=%.cmx))
 
-all: make_dirs bchcil
+all: bchcil.cmxa
 
 make_dirs:
 	@mkdir -p cmx
 	@mkdir -p cmi
 
-bchcil: $(CMIS) $(OBJECTS) $(CHLIB)/chlib.cmxa $(CIL)/goblintCil.cmxa $(EXTLIB) $(BCHLIB)/bchlib.cmxa
-	$(CAMLLINKL) -a -o bchcil.cmxa $(OBJECTS)
+bchcil.cmxa: $(CMIS) $(OBJECTS) $(CHLIB)/chlib.cmxa $(CIL)/goblintCil.cmxa $(EXTLIB) $(BCHLIB)/bchlib.cmxa
+	$(CAMLLINKL) -a -o $@ $(OBJECTS)
 
 parse: 	$(CMIS) $(OBJECTS) $(CHLIB)/chlib.cmxa $(CIL)/goblintCil.cmxa $(EXTLIB) $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa
 	$(CAMLLINK) -I $(ZARITHLIB) -o parseFile str.cmxa unix.cmxa $(ZARITHLIB)/zarith.cmxa $(CIL)/goblintCil.cmxa $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(OBJECTS)
 
 
-cmi/%.cmi: %.mli
+cmi/%.cmi: %.mli make_dirs
 	$(CAMLC) -o $@ -c -opaque $<
 
-cmx/%.cmx: %.ml
+cmx/%.cmx: %.ml make_dirs
 	$(CAMLC) -o $@ -c $<
 
 clean:
+	rm -f .depend
 	rm -f */*.cmx
 	rm -f */*.cmi
 	rm -f */*.o
@@ -79,3 +82,10 @@ clean:
 	rm -f *.cmxa
 	rm -f Makefile~
 	rm -f bchcil.cmxa
+
+.depend:
+	$(OCAMLDEP) *.mli *.ml | sed "s|[^\t ]\+\.cmx|cmx/\0|" | sed "s|[^\t ]\+\.cmi|cmi/\0|" > .depend
+
+include .depend
+
+.PHONY: all make_dirs doc clean

--- a/CodeHawk/CHB/bchcmdline/Makefile
+++ b/CodeHawk/CHB/bchcmdline/Makefile
@@ -63,6 +63,8 @@ CAMLLINK := ocamlopt str.cmxa unix.cmxa \
 	$(PWRLIB)/bchlibpower32.cmxa \
 	$(ANALYZ)/bchanalyze.cmxa \
 
+OCAMLDEP := ocamldep
+
 MLIS := \
 
 CMIS := $(addprefix cmi/,$(MLIS:%=%.cmi))
@@ -71,7 +73,7 @@ SOURCES := \
 
 OBJECTS := $(addprefix cmx/,$(SOURCES:%=%.cmx))
 
-all: make_dirs xanalyzer inspect
+all: chx86_analyze chx86_inspect_summaries
 
 make_dirs:
 	@mkdir -p cmx
@@ -79,37 +81,38 @@ make_dirs:
 
 defs: make_dirs libsum appsum constsum classsum structdef
 
-xanalyzer:  $(OBJECTS) $(CMIS) $(CHLIB)/chlib.cmxa $(CIL)/goblintCil.cmxa $(ZIPLIB)/zip.cmxa $(CHUTIL)/chutil.cmxa $(BCHCIL)/bchcil.cmxa $(BCHLIB)/bchlib.cmxa $(PELIB)/bchlibpe.cmxa $(X86LIB)/bchlibx86.cmxa $(MIPSLIB)/bchlibmips32.cmxa $(ARMLIB)/bchlibarm32.cmxa $(PWRLIB)/bchlibpower32.cmxa $(ANALYZ)/bchanalyze.cmxa cmi/bCHXBinaryAnalyzer.cmi cmx/bCHXBinaryAnalyzer.cmx
-	$(CAMLLINK) -o chx86_analyze cmx/bCHXBinaryAnalyzer.cmx
+chx86_analyze:  $(OBJECTS) $(CMIS) $(CHLIB)/chlib.cmxa $(CIL)/goblintCil.cmxa $(ZIPLIB)/zip.cmxa $(CHUTIL)/chutil.cmxa $(BCHCIL)/bchcil.cmxa $(BCHLIB)/bchlib.cmxa $(PELIB)/bchlibpe.cmxa $(X86LIB)/bchlibx86.cmxa $(MIPSLIB)/bchlibmips32.cmxa $(ARMLIB)/bchlibarm32.cmxa $(PWRLIB)/bchlibpower32.cmxa $(ANALYZ)/bchanalyze.cmxa cmi/bCHXBinaryAnalyzer.cmi cmx/bCHXBinaryAnalyzer.cmx
+	$(CAMLLINK) -o $@ cmx/bCHXBinaryAnalyzer.cmx
 
-inspect: $(OBJECTS) $(CMIS) $(CHLIB)/chlib.cmxa $(ZIPLIB)/zip.cmxa $(CHUTIL)/chutil.cmxa $(BCHLIB)/bchlib.cmxa cmi/bCHXInspectSummaries.cmi cmx/bCHXInspectSummaries.cmx
-	$(CAMLLINK) -o chx86_inspect_summaries $(OBJECTS) cmx/bCHXInspectSummaries.cmx
+chx86_inspect_summaries: $(OBJECTS) $(CMIS) $(CHLIB)/chlib.cmxa $(ZIPLIB)/zip.cmxa $(CHUTIL)/chutil.cmxa $(BCHLIB)/bchlib.cmxa cmi/bCHXInspectSummaries.cmi cmx/bCHXInspectSummaries.cmx
+	$(CAMLLINK) -o $@ $(OBJECTS) cmx/bCHXInspectSummaries.cmx
 
-export:  $(OBJECTS) $(CMIS) $(CHLIB)/chlib.cmxa $(ZIPLIB)/zip.cmxa $(CHUTIL)/chutil.cmxa $(BCHLIB)/bchlib.cmxa $(PELIB)/bchlibpe.cmxa cmx/bCHXSaveExports.cmx
-	$(CAMLLINK) -o chx86_save_exports $(OBJECTS) cmx/bCHXSaveExports.cmx
+chx86_save_exports:  $(OBJECTS) $(CMIS) $(CHLIB)/chlib.cmxa $(ZIPLIB)/zip.cmxa $(CHUTIL)/chutil.cmxa $(BCHLIB)/bchlib.cmxa $(PELIB)/bchlibpe.cmxa cmx/bCHXSaveExports.cmx
+	$(CAMLLINK) -o $@ $(OBJECTS) cmx/bCHXSaveExports.cmx
 
-libsum: $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa cmi/bCHXMakeLibSummary.cmi cmx/bCHXMakeLibSummary.cmx
-	$(CAMLLINK) -o chx86_make_lib_summary cmx/bCHXMakeLibSummary.cmx
+chx86_make_lib_summary: $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa cmi/bCHXMakeLibSummary.cmi cmx/bCHXMakeLibSummary.cmx
+	$(CAMLLINK) -o $@ cmx/bCHXMakeLibSummary.cmx
 
-appsum: $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa cmi/bCHXMakeAppSummary.cmi cmx/bCHXMakeAppSummary.cmx
-	$(CAMLLINK) -o chx86_make_app_summary cmx/bCHXMakeAppSummary.cmx
+chx86_make_app_summary: $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa cmi/bCHXMakeAppSummary.cmi cmx/bCHXMakeAppSummary.cmx
+	$(CAMLLINK) -o $@ cmx/bCHXMakeAppSummary.cmx
 
-constsum: $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa cmi/bCHXMakeConstSummary.cmi cmx/bCHXMakeConstSummary.cmx
-	$(CAMLLINK) -o chx86_make_const_summary cmx/bCHXMakeConstSummary.cmx
+chx86_make_const_summary: $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa cmi/bCHXMakeConstSummary.cmi cmx/bCHXMakeConstSummary.cmx
+	$(CAMLLINK) -o $@ cmx/bCHXMakeConstSummary.cmx
 
-classsum: $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa cmi/bCHXMakeClassSummary.cmi cmx/bCHXMakeClassSummary.cmx
-	$(CAMLLINK) -o chx86_make_class_summary cmx/bCHXMakeClassSummary.cmx
+chx86_make_class_summary: $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa cmi/bCHXMakeClassSummary.cmi cmx/bCHXMakeClassSummary.cmx
+	$(CAMLLINK) -o $@ cmx/bCHXMakeClassSummary.cmx
 
-structdef: $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa cmi/bCHXMakeStructDefinition.cmi cmx/bCHXMakeStructDefinition.cmx
-	$(CAMLLINK) -o chx86_make_structdef cmx/bCHXMakeStructDefinition.cmx
+chx86_make_structdef: $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa cmi/bCHXMakeStructDefinition.cmi cmx/bCHXMakeStructDefinition.cmx
+	$(CAMLLINK) -o $@ cmx/bCHXMakeStructDefinition.cmx
 
-cmi/%.cmi: %.mli
+cmi/%.cmi: %.mli make_dirs
 	$(CAMLC) -o $@ -c -opaque $<
 
-cmx/%.cmx: %.ml $(CMIS)
+cmx/%.cmx: %.ml make_dirs
 	$(CAMLC) -o $@ -c $<
 
 clean:
+	rm -f .depend
 	rm -f cmx/*.cm*
 	rm -f cmi/*.cmi
 	rm -f cmx/*.o
@@ -128,3 +131,10 @@ clean:
 	rm -rf chx86_make_const_summary
 	rm -rf chx86_make_structdef
 	rm -rf doc
+
+.depend:
+	$(OCAMLDEP) *.mli *.ml | sed "s|[^\t ]\+\.cmx|cmx/\0|" | sed "s|[^\t ]\+\.cmi|cmi/\0|" > .depend
+
+include .depend
+
+.PHONY: all make_dirs doc clean

--- a/CodeHawk/CHB/bchlib/Makefile
+++ b/CodeHawk/CHB/bchlib/Makefile
@@ -18,7 +18,8 @@ CAMLC := ocamlopt  -I str -I cmi -I cmx \
 	-I $(CHUTIL)/cmi \
 	-I $(XPRLIB)/cmi \
 
-CAMLLINK := ocamlopt \
+CAMLLINK := ocamlopt
+OCAMLDEP := ocamldep
 
 MLIS := \
 	bCHBCTypes \
@@ -197,22 +198,23 @@ SOURCES := \
 
 OBJECTS := $(addprefix cmx/,$(SOURCES:%=%.cmx))
 
-all: make_dirs bchlib
+all: bchlib.cmxa
 
 make_dirs:
 	@mkdir -p cmx
 	@mkdir -p cmi
 
-bchlib: $(OBJECTS) $(CMIS) $(CHLIB)/chlib.cmxa $(ZIPLIB)/zip.cmxa $(CHUTIL)/chutil.cmxa
-	$(CAMLLINK) -a -o bchlib.cmxa $(OBJECTS)
+bchlib.cmxa: $(OBJECTS) $(CMIS) $(CHLIB)/chlib.cmxa $(ZIPLIB)/zip.cmxa $(CHUTIL)/chutil.cmxa
+	$(CAMLLINK) -a -o $@ $(OBJECTS)
 
-cmi/%.cmi: %.mli
+cmi/%.cmi: %.mli make_dirs
 	$(CAMLC) -o $@ -c -opaque $<
 
-cmx/%.cmx: %.ml $(CMIS)
+cmx/%.cmx: %.ml make_dirs
 	$(CAMLC) -o $@ -c $<
 
 clean:
+	rm -f .depend
 	rm -f cmx/*.cm*
 	rm -f cmi/*.cmi
 	rm -f cmx/*.o
@@ -223,3 +225,10 @@ clean:
 	rm -f Makefile~ 
 	rm -f bchlib.cmxa
 	rm -rf doc
+
+.depend:
+	$(OCAMLDEP) *.mli *.ml | sed "s|[^\t ]\+\.cmx|cmx/\0|" | sed "s|[^\t ]\+\.cmi|cmi/\0|" > .depend
+
+include .depend
+
+.PHONY: all make_dirs doc clean

--- a/CodeHawk/CHB/bchlibarm32/Makefile
+++ b/CodeHawk/CHB/bchlibarm32/Makefile
@@ -23,7 +23,8 @@ CAMLC := ocamlopt -I str -I cmi -I cmx \
 	-I $(BCHLIB)/cmi \
 	-I $(ELFLIB)/cmi \
 
-CAMLLINK := ocamlopt \
+CAMLLINK := ocamlopt
+OCAMLDEP := ocamldep
 
 MLIS := \
 	bCHARMTypes \
@@ -92,22 +93,23 @@ SOURCES := \
 
 OBJECTS := $(addprefix cmx/,$(SOURCES:%=%.cmx))
 
-all: make_dirs bchlibarm32
+all: bchlibarm32.cmxa
 
 make_dirs:
 	@mkdir -p cmx
 	@mkdir -p cmi
 
-bchlibarm32: $(OBJECTS) $(CMIS) $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(BCHLIB)/bchlib.cmxa $(ELFLIB)/bchlibelf.cmxa
-	$(CAMLLINK) -a -o bchlibarm32.cmxa $(OBJECTS)
+bchlibarm32.cmxa: $(OBJECTS) $(CMIS) $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(BCHLIB)/bchlib.cmxa $(ELFLIB)/bchlibelf.cmxa
+	$(CAMLLINK) -a -o $@ $(OBJECTS)
 
-cmi/%.cmi: %.mli
+cmi/%.cmi: %.mli make_dirs
 	$(CAMLC) -o $@ -c -opaque $<
 
-cmx/%.cmx: %.ml $(CMIS)
+cmx/%.cmx: %.ml make_dirs
 	$(CAMLC) -o $@ -c $<
 
 clean:
+	rm -f .depend
 	rm -f cmx/*.cm*
 	rm -f cmi/*.cmi
 	rm -f cmx/*.o
@@ -117,3 +119,10 @@ clean:
 	rm -f *.mli~
 	rm -f Makefile~ 
 	rm -rf doc
+
+.depend:
+	$(OCAMLDEP) *.mli *.ml | sed "s|[^\t ]\+\.cmx|cmx/\0|" | sed "s|[^\t ]\+\.cmi|cmi/\0|" > .depend
+
+include .depend
+
+.PHONY: all make_dirs doc clean

--- a/CodeHawk/CHB/bchlibelf/Makefile
+++ b/CodeHawk/CHB/bchlibelf/Makefile
@@ -31,6 +31,8 @@ CAMLBUILD := ocamlopt str.cmxa unix.cmxa \
 	$(BCHCIL)/bchcil.cmxa \
 	$(PELIB)/bchlibpe.cmxa
 
+OCAMLDEP := ocamldep
+
 MLIS := \
 	bCHDwarfTypes \
 	bCHELFTypes \
@@ -89,7 +91,7 @@ SOURCES := \
 
 OBJECTS := $(addprefix cmx/,$(SOURCES:%=%.cmx))
 
-all: make_dirs bchlibelf
+all: bchlibelf.cmxa
 
 make_dirs:
 	@mkdir -p cmx
@@ -98,16 +100,17 @@ make_dirs:
 mtest: $(OBJECTS) cmx/test.cmx $(CMIS) $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(X86LIB)/bchlibx86.cmxa
 	$(CAMLBUILD) -o mtest $(OBJECTS) cmx/test.cmx
 
-bchlibelf: $(OBJECTS) $(CMIS) $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(BCHLIB)/bchlib.cmxa $(PELIB)/bchlibpe.cmxa
-	$(CAMLLINK) -a -o bchlibelf.cmxa $(OBJECTS)
+bchlibelf.cmxa: $(OBJECTS) $(CMIS) $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(BCHLIB)/bchlib.cmxa $(PELIB)/bchlibpe.cmxa
+	$(CAMLLINK) -a -o $@ $(OBJECTS)
 
-cmi/%.cmi: %.mli
+cmi/%.cmi: %.mli make_dirs
 	$(CAMLC) -o $@ -c -opaque $<
 
-cmx/%.cmx: %.ml $(CMIS)
+cmx/%.cmx: %.ml make_dirs
 	$(CAMLC) -o $@ -c $<
 
 clean:
+	rm -f .depend
 	rm -f cmx/*.cmx
 	rm -f cmi/*.cmi
 	rm -f cmx/*.o
@@ -119,3 +122,10 @@ clean:
 	rm -rf bchlibelf
 	rm -rf doc
 	rm -f mtest
+
+.depend:
+	$(OCAMLDEP) *.mli *.ml | sed "s|[^\t ]\+\.cmx|cmx/\0|" | sed "s|[^\t ]\+\.cmi|cmi/\0|" > .depend
+
+include .depend
+
+.PHONY: all make_dirs doc clean

--- a/CodeHawk/CHB/bchlibmips32/Makefile
+++ b/CodeHawk/CHB/bchlibmips32/Makefile
@@ -21,7 +21,8 @@ CAMLC := ocamlopt  -I str -I cmi -I cmx \
 	-I $(BCHLIB)/cmi \
 	-I $(ELFLIB)/cmi \
 
-CAMLLINK := ocamlopt \
+CAMLLINK := ocamlopt
+OCAMLDEP := ocamldep
 
 MLIS := \
 	bCHMIPSTypes \
@@ -72,22 +73,23 @@ SOURCES := \
 
 OBJECTS := $(addprefix cmx/,$(SOURCES:%=%.cmx))
 
-all: make_dirs bchlibmips32
+all: bchlibmips32.cmxa
 
 make_dirs:
 	@mkdir -p cmx
 	@mkdir -p cmi
 
-bchlibmips32: $(OBJECTS) $(CMIS) $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(BCHLIB)/bchlib.cmxa $(ELFLIB)/bchlibelf.cmxa
-	$(CAMLLINK) -a -o bchlibmips32.cmxa $(OBJECTS)
+bchlibmips32.cmxa: $(OBJECTS) $(CMIS) $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(BCHLIB)/bchlib.cmxa $(ELFLIB)/bchlibelf.cmxa
+	$(CAMLLINK) -a -o $@ $(OBJECTS)
 
-cmi/%.cmi: %.mli
+cmi/%.cmi: %.mli make_dirs
 	$(CAMLC) -o $@ -c -opaque $<
 
-cmx/%.cmx: %.ml $(CMIS)
+cmx/%.cmx: %.ml make_dirs
 	$(CAMLC) -o $@ -c $<
 
 clean:
+	rm -f .depend
 	rm -f cmx/*.cm*
 	rm -f cmi/*.cmi
 	rm -f cmx/*.o
@@ -97,3 +99,10 @@ clean:
 	rm -f *.mli~
 	rm -f Makefile~ 
 	rm -rf doc
+
+.depend:
+	$(OCAMLDEP) *.mli *.ml | sed "s|[^\t ]\+\.cmx|cmx/\0|" | sed "s|[^\t ]\+\.cmi|cmi/\0|" > .depend
+
+include .depend
+
+.PHONY: all make_dirs doc clean

--- a/CodeHawk/CHB/bchlibpe/Makefile
+++ b/CodeHawk/CHB/bchlibpe/Makefile
@@ -16,7 +16,8 @@ CAMLC := ocamlopt -I str -I cmi -I cmx \
 	-I $(XPRLIB)/cmi \
 	-I $(BCHLIB)/cmi \
 
-CAMLLINK := ocamlopt \
+CAMLLINK := ocamlopt
+OCAMLDEP := ocamldep
 
 MLIS := \
 	bCHLibPETypes \
@@ -51,22 +52,23 @@ SOURCES := \
 
 OBJECTS := $(addprefix cmx/,$(SOURCES:%=%.cmx))
 
-all: make_dirs bchlibpe
+all: bchlibpe.cmxa
 
 make_dirs:
 	@mkdir -p cmx
 	@mkdir -p cmi
 
-bchlibpe: $(OBJECTS) $(CMIS) $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(BCHLIB)/bchlib.cmxa
-	$(CAMLLINK) -a -o bchlibpe.cmxa $(OBJECTS)
+bchlibpe.cmxa: $(OBJECTS) $(CMIS) $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(BCHLIB)/bchlib.cmxa
+	$(CAMLLINK) -a -o $@ $(OBJECTS)
 
-cmi/%.cmi: %.mli
+cmi/%.cmi: %.mli make_dirs
 	$(CAMLC) -o $@ -c -opaque $<
 
-cmx/%.cmx: %.ml $(CMIS)
+cmx/%.cmx: %.ml make_dirs
 	$(CAMLC) -o $@ -c $<
 
 clean:
+	rm -f .depend
 	rm -f cmx/*.cmx
 	rm -f cmi/*.cmi
 	rm -f cmx/*.o
@@ -77,3 +79,10 @@ clean:
 	rm -f Makefile~ 
 	rm -rf bchlibpe
 	rm -rf doc
+
+.depend:
+	$(OCAMLDEP) *.mli *.ml | sed "s|[^\t ]\+\.cmx|cmx/\0|" | sed "s|[^\t ]\+\.cmi|cmi/\0|" > .depend
+
+include .depend
+
+.PHONY: all make_dirs doc clean

--- a/CodeHawk/CHB/bchlibpower32/Makefile
+++ b/CodeHawk/CHB/bchlibpower32/Makefile
@@ -23,7 +23,8 @@ CAMLC := ocamlopt  -I str -I cmi -I cmx \
 	-I $(BCHLIB)/cmi \
 	-I $(ELFLIB)/cmi \
 
-CAMLLINK := ocamlopt \
+CAMLLINK := ocamlopt
+OCAMLDEP := ocamldep
 
 MLIS := \
 	bCHPowerTypes \
@@ -81,22 +82,23 @@ SOURCES := \
 
 OBJECTS := $(addprefix cmx/,$(SOURCES:%=%.cmx))
 
-all: make_dirs bchlibpower32
+all: bchlibpower32.cmxa
 
 make_dirs:
 	@mkdir -p cmx
 	@mkdir -p cmi
 
-bchlibpower32: $(OBJECTS) $(CMIS) $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(BCHLIB)/bchlib.cmxa $(ELFLIB)/bchlibelf.cmxa
-	$(CAMLLINK) -a -o bchlibpower32.cmxa $(OBJECTS)
+bchlibpower32.cmxa: $(OBJECTS) $(CMIS) $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(BCHLIB)/bchlib.cmxa $(ELFLIB)/bchlibelf.cmxa
+	$(CAMLLINK) -a -o $@ $(OBJECTS)
 
-cmi/%.cmi: %.mli
+cmi/%.cmi: %.mli make_dirs
 	$(CAMLC) -o $@ -c -opaque $<
 
-cmx/%.cmx: %.ml $(CMIS)
+cmx/%.cmx: %.ml make_dirs
 	$(CAMLC) -o $@ -c $<
 
 clean:
+	rm -f .depend
 	rm -f cmx/*.cm*
 	rm -f cmi/*.cmi
 	rm -f cmx/*.o
@@ -106,3 +108,10 @@ clean:
 	rm -f *.mli~
 	rm -f Makefile~ 
 	rm -rf doc
+
+.depend:
+	$(OCAMLDEP) *.mli *.ml | sed "s|[^\t ]\+\.cmx|cmx/\0|" | sed "s|[^\t ]\+\.cmi|cmi/\0|" > .depend
+
+include .depend
+
+.PHONY: all make_dirs doc clean

--- a/CodeHawk/CHB/bchlibx86/Makefile
+++ b/CodeHawk/CHB/bchlibx86/Makefile
@@ -25,7 +25,8 @@ CAMLC := ocamlopt -I str -I cmi -I cmx \
 	-I $(PELIB)/cmi \
 	-I $(ELFLIB)/cmi \
 
-CAMLLINK := ocamlopt \
+CAMLLINK := ocamlopt
+OCAMLDEP := ocamldep
 
 MLIS := \
 	bCHLibx86Types \
@@ -154,22 +155,23 @@ SOURCES := \
 
 OBJECTS := $(addprefix cmx/,$(SOURCES:%=%.cmx))
 
-all: make_dirs bchlibx86
+all: bchlibx86.cmxa
 
 make_dirs:
 	@mkdir -p cmx
 	@mkdir -p cmi
 
-bchlibx86: $(OBJECTS) $(CMIS) $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(BCHCIL)/bchcil.cmxa $(BCHLIB)/bchlib.cmxa $(PELIB)/bchlibpe.cmxa $(ELFLIB)/bchlibelf.cmxa
-	$(CAMLLINK) -a -o bchlibx86.cmxa $(OBJECTS)
+bchlibx86.cmxa: $(OBJECTS) $(CMIS) $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(BCHCIL)/bchcil.cmxa $(BCHLIB)/bchlib.cmxa $(PELIB)/bchlibpe.cmxa $(ELFLIB)/bchlibelf.cmxa
+	$(CAMLLINK) -a -o $@ $(OBJECTS)
 
-cmi/%.cmi: %.mli
+cmi/%.cmi: %.mli make_dirs
 	$(CAMLC) -o $@ -c -opaque $<
 
-cmx/%.cmx: %.ml $(CMIS)
+cmx/%.cmx: %.ml make_dirs
 	$(CAMLC) -o $@ -c $<
 
 clean:
+	rm -f .depend
 	rm -f cmx/*.cm*
 	rm -f cmi/*.cmi
 	rm -f cmx/*.o
@@ -179,3 +181,10 @@ clean:
 	rm -f *.mli~
 	rm -f Makefile~ 
 	rm -rf doc
+
+.depend:
+	$(OCAMLDEP) *.mli *.ml | sed "s|[^\t ]\+\.cmx|cmx/\0|" | sed "s|[^\t ]\+\.cmi|cmi/\0|" > .depend
+
+include .depend
+
+.PHONY: all make_dirs doc clean

--- a/CodeHawk/CHC/cchanalyze/Makefile
+++ b/CodeHawk/CHC/cchanalyze/Makefile
@@ -27,6 +27,8 @@ CAMLLINK := ocamlopt  \
 	-I $(CCHLIB)/cmi \
 	-I $(CCHPRE)/cmi \
 
+OCAMLDEP := ocamldep
+
 MLIS := \
 	cCHAnalysisTypes \
 	cCHNumericalConstraints \
@@ -158,22 +160,23 @@ SOURCES := \
 
 OBJECTS := $(addprefix cmx/,$(SOURCES:%=%.cmx))
 
-all: make_dirs cchanalyze
+all: cchanalyze.cmxa
 
 make_dirs:
 	@mkdir -p cmx
 	@mkdir -p cmi
 
-cchanalyze: $(CMIS) $(OBJECTS) $(CHLIB)/chlib.cmxa $(CCHLIB)/cchlib.cmxa
+cchanalyze.cmxa: $(CMIS) $(OBJECTS) $(CHLIB)/chlib.cmxa $(CCHLIB)/cchlib.cmxa
 	$(CAMLLINK) -a -o cchanalyze.cmxa $(OBJECTS)
 
-cmi/%.cmi: %.mli
+cmi/%.cmi: %.mli make_dirs
 	$(CAMLC) -o $@ -c -opaque $<
 
-cmx/%.cmx: %.ml
+cmx/%.cmx: %.ml make_dirs
 	$(CAMLC) -o $@ -c $<
 
 clean:
+	rm -f .depend
 	rm -f */*.cmx
 	rm -f */*.cmi
 	rm -f */*.o
@@ -188,3 +191,10 @@ clean:
 	rm -f testinvariants
 	rm -f checkpo
 	rm -f call_checkpo
+
+.depend:
+	$(OCAMLDEP) *.mli *.ml | sed "s|[^\t ]\+\.cmx|cmx/\0|" | sed "s|[^\t ]\+\.cmi|cmi/\0|" > .depend
+
+include .depend
+
+.PHONY: all make_dirs doc clean

--- a/CodeHawk/CHC/cchcil/Makefile
+++ b/CodeHawk/CHC/cchcil/Makefile
@@ -20,7 +20,8 @@ CAMLLINK := ocamlopt  \
 	$(CHLIB)/chlib.cmxa \
 	$(CHUTIL)/chutil.cmxa \
 
-CAMLLINKLIB := ocamlopt  \
+CAMLLINKLIB := ocamlopt
+OCAMLDEP = ocamldep
 
 MLIS := \
 	cHCilFileUtil \
@@ -45,26 +46,27 @@ SOURCES := \
 
 OBJECTS := $(addprefix cmx/,$(SOURCES:%=%.cmx))
 
-all: make_dirs parse cchcil
+all: parseFile cchcil.cmxa
 
 make_dirs:
 	@mkdir -p cmx
 	@mkdir -p cmi
 
-parse: 	$(CMIS) $(OBJECTS) $(CHLIB)/chlib.cmxa $(CIL)/goblintCil.cmxa $(EXTLIB) $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa
+parseFile: 	$(CMIS) $(OBJECTS) $(CHLIB)/chlib.cmxa $(CIL)/goblintCil.cmxa $(EXTLIB) $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa
 	$(CAMLLINK) -I $(ZARITHLIB) -o parseFile str.cmxa unix.cmxa $(ZARITHLIB)/zarith.cmxa $(CIL)/goblintCil.cmxa $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(OBJECTS)
 
-cchcil: $(CMIS) $(OBJECTS) $(CHLIB)/chlib.cmxa $(CIL)/goblintCil.cmxa $(EXTLIB) $(CHUTIL)/chutil.cmxa
-	$(CAMLLINKLIB) -a -o cchcil.cmxa $(OBJECTS)
+cchcil.cmxa: $(CMIS) $(OBJECTS) $(CHLIB)/chlib.cmxa $(CIL)/goblintCil.cmxa $(EXTLIB) $(CHUTIL)/chutil.cmxa
+	$(CAMLLINKLIB) -a -o $@ $(OBJECTS)
 
 
-cmi/%.cmi: %.mli
+cmi/%.cmi: %.mli make_dirs
 	$(CAMLC) -o $@ -c $<
 
-cmx/%.cmx: %.ml
+cmx/%.cmx: %.ml make_dirs
 	$(CAMLC) -o $@ -c $<
 
 clean:
+	rm -f .depend
 	rm -f */*.cmx
 	rm -f */*.cmi
 	rm -f */*.o
@@ -73,3 +75,10 @@ clean:
 	rm -f *.cmxa
 	rm -f Makefile~
 	rm -f parseFile
+
+.depend:
+	$(OCAMLDEP) *.mli *.ml | sed "s|[^\t ]\+\.cmx|cmx/\0|" | sed "s|[^\t ]\+\.cmi|cmi/\0|" > .depend
+
+include .depend
+
+.PHONY: all make_dirs doc clean

--- a/CodeHawk/CHC/cchcmdline/Makefile
+++ b/CodeHawk/CHC/cchcmdline/Makefile
@@ -40,17 +40,19 @@ CAMLBUILD := ocamlopt str.cmxa unix.cmxa  \
 	$(CCHPRE)/cchpre.cmxa \
 	$(CCHANALYZE)/cchanalyze.cmxa
 
-all: dirs canalyzer inspect
+OCAMLDEP := ocamldep
+
+all: canalyzer inspectsummaries
 
 dirs:
 	@mkdir -p cmx
 	@mkdir -p cmi
 
-inspect: dirs $(CHLIB)/chlib.cmxa $(CCHLIB)/cchlib.cmxa $(CCHPRE)/cchpre.cmxa cmx/cCHXInspectSummaries.cmx
-	$(CAMLBUILD) -o inspectsummaries cmx/cCHXInspectSummaries.cmx
+inspectsummaries: dirs $(CHLIB)/chlib.cmxa $(CCHLIB)/cchlib.cmxa $(CCHPRE)/cchpre.cmxa cmx/cCHXInspectSummaries.cmx
+	$(CAMLBUILD) -o $@ cmx/cCHXInspectSummaries.cmx
 
 canalyzer: $(CHLIB)/chlib.cmxa $(CCHLIB)/cchlib.cmxa $(CCHPRE)/cchpre.cmxa $(CCHANALYZE)/cchanalyze.cmxa cmi/cCHVersion.cmi cmx/cCHVersion.cmx cmi/cCHXCAnalyzer.cmi cmx/cCHXCAnalyzer.cmx
-	$(CAMLBUILD) -o canalyzer cmx/cCHVersion.cmx cmx/cCHXCAnalyzer.cmx
+	$(CAMLBUILD) -o $@ cmx/cCHVersion.cmx cmx/cCHXCAnalyzer.cmx
 
 capplication: dirs $(CHLIB)/chlib.cmxa $(CCHLIB)/cchlib.cmxa $(CCHPRE)/cchpre.cmxa $(CCHANALYZE)/cchanalyze.cmxa cmi/cCHVersion.cmi cmx/cCHVersion.cmx cmi/cCHXCAnalyzer.cmi cmx/cCHXCApplication.cmx
 	$(CAMLBUILD) -o capplication cmx/cCHVersion.cmx cmx/cCHXCApplication.cmx
@@ -58,13 +60,14 @@ capplication: dirs $(CHLIB)/chlib.cmxa $(CCHLIB)/cchlib.cmxa $(CCHPRE)/cchpre.cm
 canalyzer_object: dirs $(CHLIB)/chlib.cmxa $(CCHLIB)/cchlib.cmxa $(CCHPRE)/cchpre.cmxa $(CCHANALYZE)/cchanalyze.cmxa cmi/cCHVersion.cmi cmx/cCHVersion.cmx cmi/cCHXCAnalyzer.cmi cmx/cCHXCAnalyzer.cmx
 	$(CAMLBUILD) -output-obj -o $(COBJ)/canalyzer.o cmx/cCHVersion.cmx cmx/cCHXCAnalyzer.cmx
 
-cmi/%.cmi: %.mli
+cmi/%.cmi: %.mli dirs
 	$(CAMLC) -o $@ -c $<
 
-cmx/%.cmx: %.ml
+cmx/%.cmx: %.ml dirs
 	$(CAMLC) -o $@ -c $<
 
 clean:
+	rm -f .depend
 	rm -f */*.cmx
 	rm -f */*.cmi
 	rm -f */*.o
@@ -77,3 +80,10 @@ clean:
 	rm -f inspectsummaries
 	rm -f canalyzer
 	rm -f capplication
+
+.depend:
+	$(OCAMLDEP) *.mli *.ml | sed "s|[^\t ]\+\.cmx|cmx/\0|" | sed "s|[^\t ]\+\.cmi|cmi/\0|" > .depend
+
+include .depend
+
+.PHONY: all dirs canalyzer_object clean

--- a/CodeHawk/CHC/cchlib/Makefile
+++ b/CodeHawk/CHC/cchlib/Makefile
@@ -23,6 +23,8 @@ CAMLLINK := ocamlopt  \
 	-I $(CHUTIL) \
 	-I $(XPRLIB) \
 
+OCAMLDEP = ocamldep
+
 MLIS := \
 	cCHBasicTypes \
 	cCHLibTypes \
@@ -77,23 +79,24 @@ SOURCES := \
 
 OBJECTS := $(addprefix cmx/,$(SOURCES:%=%.cmx))
 
-all: make_dirs cchlib
+all: cchlib.cmxa
 
 make_dirs:
 	@mkdir -p cmx
 	@mkdir -p cmi
 
-cchlib: $(CMIS) $(OBJECTS) $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(XPRLIB)/xpr.cmxa
-	$(CAMLLINK) -a -o cchlib.cmxa $(OBJECTS)
+cchlib.cmxa: $(CMIS) $(OBJECTS) $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(XPRLIB)/xpr.cmxa
+	$(CAMLLINK) -a -o $@ $(OBJECTS)
 
 
-cmi/%.cmi: %.mli
+cmi/%.cmi: %.mli make_dirs
 	$(CAMLC) -o $@ -c -opaque $<
 
-cmx/%.cmx: %.ml
+cmx/%.cmx: %.ml make_dirs
 	$(CAMLC) -o $@ -c $<
 
 clean:
+	rm -f .depend
 	rm -f */*.cmx
 	rm -f */*.cmi
 	rm -f */*.o
@@ -101,3 +104,10 @@ clean:
 	rm -f *.a
 	rm -f *.cmxa
 	rm -f Makefile~	
+
+.depend:
+	$(OCAMLDEP) *.mli *.ml | sed "s|[^\t ]\+\.cmx|cmx/\0|" | sed "s|[^\t ]\+\.cmi|cmi/\0|" > .depend
+
+include .depend
+
+.PHONY: all make_dirs doc clean

--- a/CodeHawk/CHC/cchpre/Makefile
+++ b/CodeHawk/CHC/cchpre/Makefile
@@ -30,6 +30,8 @@ CAMLBUILD := ocamlopt str.cmxa unix.cmxa \
 	$(ZIPLIB)/zip.cmxa \
 	$(CCHLIB)/cchlib.cmxa \
 
+OCAMLDEP := ocamldep
+
 MLIS := \
 	cCHPreTypes \
 	cCHPreSumTypeSerializer \
@@ -102,22 +104,23 @@ SOURCES := \
 
 OBJECTS := $(addprefix cmx/,$(SOURCES:%=%.cmx))
 
-all: make_dirs cchpre
+all: cchpre.cmxa
 
 make_dirs:
 	@mkdir -p cmx
 	@mkdir -p cmi
 
-cchpre: $(CMIS) $(OBJECTS) $(CHLIB)/chlib.cmxa $(CCHLIB)/cchlib.cmxa
-	$(CAMLLINK) -a -o cchpre.cmxa $(OBJECTS)
+cchpre.cmxa: $(CMIS) $(OBJECTS) $(CHLIB)/chlib.cmxa $(CCHLIB)/cchlib.cmxa
+	$(CAMLLINK) -a -o $@ $(OBJECTS)
 
-cmi/%.cmi: %.mli
+cmi/%.cmi: %.mli make_dirs
 	$(CAMLC) -o $@ -c -opaque $<
 
-cmx/%.cmx: %.ml
+cmx/%.cmx: %.ml make_dirs
 	$(CAMLC) -o $@ -c $<
 
 clean:
+	rm -f .depend
 	rm -f *.cmx
 	rm -f *.cmi
 	rm -f */*.cmx
@@ -133,3 +136,10 @@ clean:
 	rm -f call_chlink
 	rm -f createprimary
 	rm -f createsecondary
+
+.depend:
+	$(OCAMLDEP) *.mli *.ml | sed "s|[^\t ]\+\.cmx|cmx/\0|" | sed "s|[^\t ]\+\.cmi|cmi/\0|" > .depend
+
+include .depend
+
+.PHONY: all make_dirs doc clean

--- a/CodeHawk/CHJ/jchcmdline/Makefile
+++ b/CodeHawk/CHJ/jchcmdline/Makefile
@@ -31,38 +31,39 @@ CAMLBUILD := ocamlopt str.cmxa unix.cmxa \
 
 CAMLDOC := ocamldoc
 JAVAC = javac
+OCAMLDEP := ocamldep
 
-all: make_dirs template integrate inspect native experiment
+all: chj_template chj_integrate chj_inspect chj_native chj_experiment
 
 make_dirs:
 	@mkdir -p cmx
 	@mkdir -p cmi
 
 # program to experiment with applying certain functionality to a single class
-experiment: cmi/jCHXClassExperiment.cmi cmx/jCHXClassExperiment.cmx $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(JCHLIB)/jchlib.cmxa $(JCHPRE)/jchpre.cmxa
-	$(CAMLBUILD) -o chj_experiment cmx/jCHXClassExperiment.cmx
+chj_experiment: cmi/jCHXClassExperiment.cmi cmx/jCHXClassExperiment.cmx $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(JCHLIB)/jchlib.cmxa $(JCHPRE)/jchpre.cmxa
+	$(CAMLBUILD) -o $@ cmx/jCHXClassExperiment.cmx
 
 # program to generate xml starting point for library method summaries
-template: cmi/jCHXTemplate.cmi cmx/jCHXTemplate.cmx $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(JCHLIB)/jchlib.cmxa $(JCHPRE)/jchpre.cmxa
-	$(CAMLBUILD) -o chj_template cmx/jCHXTemplate.cmx
+chj_template: cmi/jCHXTemplate.cmi cmx/jCHXTemplate.cmx $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(JCHLIB)/jchlib.cmxa $(JCHPRE)/jchpre.cmxa
+	$(CAMLBUILD) -o $@ cmx/jCHXTemplate.cmx
 
 # program to integrate platform-independent and platform dependent library summaries
-integrate: cmi/jCHXIntegrateSummaries.cmi cmx/jCHXIntegrateSummaries.cmx $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(JCHLIB)/jchlib.cmxa $(JCHPRE)/jchpre.cmxa
-	$(CAMLBUILD) -o chj_integrate cmx/jCHXIntegrateSummaries.cmx
+chj_integrate: cmi/jCHXIntegrateSummaries.cmi cmx/jCHXIntegrateSummaries.cmx $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(JCHLIB)/jchlib.cmxa $(JCHPRE)/jchpre.cmxa
+	$(CAMLBUILD) -o $@ cmx/jCHXIntegrateSummaries.cmx
 
 # program to inspect library method summaries for syntactic correctness and semantic consistency
-inspect: cmi/jCHXInspectSummaries.cmi cmx/jCHXInspectSummaries.cmx $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(JCHLIB)/jchlib.cmxa $(JCHPRE)/jchpre.cmxa
-	$(CAMLBUILD) -o chj_inspect cmx/jCHXInspectSummaries.cmx
+chj_inspect: cmi/jCHXInspectSummaries.cmi cmx/jCHXInspectSummaries.cmx $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(JCHLIB)/jchlib.cmxa $(JCHPRE)/jchpre.cmxa
+	$(CAMLBUILD) -o $@ cmx/jCHXInspectSummaries.cmx
 
 # program to generate class xml files with the signatures of native methods (NM)
-native: cmi/jCHXNativeMethodSignatures.cmi cmx/jCHXNativeMethodSignatures.cmx $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(JCHLIB)/jchlib.cmxa $(JCHPRE)/jchpre.cmxa
-	$(CAMLBUILD) -o chj_native cmx/jCHXNativeMethodSignatures.cmx
+chj_native: cmi/jCHXNativeMethodSignatures.cmi cmx/jCHXNativeMethodSignatures.cmx $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(JCHLIB)/jchlib.cmxa $(JCHPRE)/jchpre.cmxa
+	$(CAMLBUILD) -o $@ cmx/jCHXNativeMethodSignatures.cmx
 
 
-cmi/%.cmi: %.mli
+cmi/%.cmi: %.mli make_dirs
 	$(CAMLC) -o $@ -c $<
 
-cmx/%.cmx: %.ml
+cmx/%.cmx: %.ml make_dirs
 	$(CAMLC) -o $@ -c $<
 
 
@@ -70,6 +71,7 @@ cleanjava:
 	rm -f *.class
 
 clean:
+	rm -f .depend
 	rm -f */*.cmx
 	rm -f */*.cmi
 	rm -f */*.o
@@ -83,3 +85,10 @@ clean:
 	rm -f chj_integrate
 	rm -f chj_inspect
 	rm -f chj_native
+
+.depend:
+	$(OCAMLDEP) *.mli *.ml | sed "s|[^\t ]\+\.cmx|cmx/\0|" | sed "s|[^\t ]\+\.cmi|cmi/\0|" > .depend
+
+include .depend
+
+.PHONY: all make_dirs doc clean

--- a/CodeHawk/CHJ/jchcost/Makefile
+++ b/CodeHawk/CHJ/jchcost/Makefile
@@ -20,6 +20,8 @@ CAMLC := ocamlopt -I +str -I +unix -I cmi -I cmx \
 	-I $(JCHSYS)/cmi \
 	-I $(JCHPOLY)/cmi \
 
+OCAMLDEP := ocamldep
+
 MLIS = \
 	jCHCostAPI \
 	jCHOpcodeCosts \
@@ -49,22 +51,23 @@ SOURCES = \
 
 OBJECTS := $(addprefix cmx/,$(SOURCES:%=%.cmx))
 
-all: make_dirs jchcost
+all: jchcost.cmxa
 
 make_dirs:
 	@mkdir -p cmx
 	@mkdir -p cmi
 
-jchcost: $(CMIS) $(OBJECTS) $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(JCHLIB)/jchlib.cmxa $(JCHPRE)/jchpre.cmxa $(JCHSYS)/jchsys.cmxa $(JCHPOLY)/jchpoly.cmxa
-	$(CAMLC) -a -o jchcost.cmxa $(OBJECTS)
+jchcost.cmxa: $(CMIS) $(OBJECTS) $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(JCHLIB)/jchlib.cmxa $(JCHPRE)/jchpre.cmxa $(JCHSYS)/jchsys.cmxa $(JCHPOLY)/jchpoly.cmxa
+	$(CAMLC) -a -o $@ $(OBJECTS)
 
-cmi/%.cmi: %.mli
+cmi/%.cmi: %.mli make_dirs
 	$(CAMLC) -o $@ -c -opaque $<
 
-cmx/%.cmx: %.ml
+cmx/%.cmx: %.ml make_dirs
 	$(CAMLC) -o $@ -c $<
 
 clean:
+	rm -f .depend
 	rm -f */*.cmx
 	rm -f */*.cmi
 	rm -f */*.o
@@ -72,3 +75,10 @@ clean:
 	rm -f *.a
 	rm -f *.cmxa
 	rm -f Makefile~	
+
+.depend:
+	$(OCAMLDEP) *.mli *.ml | sed "s|[^\t ]\+\.cmx|cmx/\0|" | sed "s|[^\t ]\+\.cmi|cmi/\0|" > .depend
+
+include .depend
+
+.PHONY: all make_dirs doc clean

--- a/CodeHawk/CHJ/jchfeatures/Makefile
+++ b/CodeHawk/CHJ/jchfeatures/Makefile
@@ -14,6 +14,8 @@ CAMLC := ocamlopt -I str -I cmi -I cmx \
 	-I $(JCHLIB)/cmi \
 	-I $(JCHPRE)/cmi \
 
+OCAMLDEP := ocamldep
+
 MLIS = \
 	jCHFeaturesAPI \
 	jCHSubgraph \
@@ -35,22 +37,23 @@ SOURCES = \
 
 OBJECTS := $(addprefix cmx/,$(SOURCES:%=%.cmx))
 
-all: make_dirs jchfeatures
+all: jchfeatures.cmxa
 
 make_dirs:
 	@mkdir -p cmx
 	@mkdir -p cmi
 
-jchfeatures: $(CMIS) $(OBJECTS) $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(JCHLIB)/jchlib.cmxa $(JCHPRE)/jchpre.cmxa
-	$(CAMLC) -a -o jchfeatures.cmxa $(OBJECTS)
+jchfeatures.cmxa: $(CMIS) $(OBJECTS) $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(JCHLIB)/jchlib.cmxa $(JCHPRE)/jchpre.cmxa
+	$(CAMLC) -a -o $@ $(OBJECTS)
 
-cmi/%.cmi: %.mli
+cmi/%.cmi: %.mli make_dirs
 	$(CAMLC) -o $@ -c -opaque $<
 
-cmx/%.cmx: %.ml
+cmx/%.cmx: %.ml make_dirs
 	$(CAMLC) -o $@ -c $<
 
 clean:
+	rm -f .depend
 	rm -f */*.cmx
 	rm -f */*.cmi
 	rm -f */*.o
@@ -59,3 +62,9 @@ clean:
 	rm -f *.cmxa
 	rm -f Makefile~	
 
+.depend:
+	$(OCAMLDEP) *.mli *.ml | sed "s|[^\t ]\+\.cmx|cmx/\0|" | sed "s|[^\t ]\+\.cmi|cmi/\0|" > .depend
+
+include .depend
+
+.PHONY: all make_dirs doc clean

--- a/CodeHawk/CHJ/jchlib/Makefile
+++ b/CodeHawk/CHJ/jchlib/Makefile
@@ -15,6 +15,8 @@ CAMLC := ocamlopt -I +str -I +unix -I cmi -I cmx \
 	-I $(CHLIB)/cmi \
 	-I $(CHUTIL)/cmi \
 
+OCAMLDEP := ocamldep
+
 MLIS := \
 	jCHIFUtil \
 	jCHBasicTypesAPI \
@@ -81,19 +83,19 @@ SOURCES := \
 
 OBJECTS := $(addprefix cmx/,$(SOURCES:%=%.cmx))
 
-all: make_dirs jchlib
+all: jchlib.cmxa
 
 make_dirs:
 	@mkdir -p cmx
 	@mkdir -p cmi
 
-jchlib: $(CMIS) $(OBJECTS) $(CHLIB)/chlib.cmxa $(ZIPLIB)/zip.cmxa $(CHUTIL)/chutil.cmxa
-	$(CAMLC) -a -o jchlib.cmxa $(OBJECTS)
+jchlib.cmxa: $(CMIS) $(OBJECTS) $(CHLIB)/chlib.cmxa $(ZIPLIB)/zip.cmxa $(CHUTIL)/chutil.cmxa
+	$(CAMLC) -a -o $@ $(OBJECTS)
 
-cmi/%.cmi: %.mli
+cmi/%.cmi: %.mli make_dirs
 	$(CAMLC) -o $@ -c -opaque $<
 
-cmx/%.cmx: %.ml
+cmx/%.cmx: %.ml make_dirs
 	$(CAMLC) -o $@ -c $<
 
 clean:
@@ -104,3 +106,10 @@ clean:
 	rm -f *.a
 	rm -f *.cmxa
 	rm -f Makefile~
+
+.depend:
+	$(OCAMLDEP) *.mli *.ml | sed "s|[^\t ]\+\.cmx|cmx/\0|" | sed "s|[^\t ]\+\.cmi|cmi/\0|" > .depend
+
+include .depend
+
+.PHONY: all make_dirs doc clean

--- a/CodeHawk/CHJ/jchmuse/Makefile
+++ b/CodeHawk/CHJ/jchmuse/Makefile
@@ -67,11 +67,13 @@ CAMLBUILDPOLY := ocamlopt str.cmxa unix.cmxa \
 	$(JCHSYS)/jchsys.cmxa \
 	$(JCHPOLY)/jchpoly.cmxa \
 
+OCAMLDEP := ocamldep
+
 
 CAMLDOC := ocamldoc
 JAVAC = javac
 
-all: make_dirs features exprfeatures pattern poly
+all: chj_features chj_efeatures chj_patterns chj_invariants
 
 make_dirs:
 	@mkdir -p cmx
@@ -79,31 +81,32 @@ make_dirs:
 
 
 # program to generate key-value pairs (MUSE)
-features: cmi/jCHXExtractFeatures.cmi cmx/jCHXExtractFeatures.cmx $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(JCHLIB)/jchlib.cmxa $(JCHPRE)/jchpre.cmxa $(JCHFEA)/jchfeatures.cmxa
+chj_features: cmi/jCHXExtractFeatures.cmi cmx/jCHXExtractFeatures.cmx $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(JCHLIB)/jchlib.cmxa $(JCHPRE)/jchpre.cmxa $(JCHFEA)/jchfeatures.cmxa
 	$(CAMLBUILD) -o chj_features cmx/jCHXExtractFeatures.cmx
 
-exprfeatures: cmi/jCHXExtractExprFeatures.cmi cmx/jCHXExtractExprFeatures.cmx $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(JCHLIB)/jchlib.cmxa $(JCHPRE)/jchpre.cmxa $(JCHFEA)/jchfeatures.cmxa
-	$(CAMLBUILD) -o chj_efeatures cmx/jCHXExtractExprFeatures.cmx
+chj_efeatures: cmi/jCHXExtractExprFeatures.cmi cmx/jCHXExtractExprFeatures.cmx $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(JCHLIB)/jchlib.cmxa $(JCHPRE)/jchpre.cmxa $(JCHFEA)/jchfeatures.cmxa
+	$(CAMLBUILD) -o $@ cmx/jCHXExtractExprFeatures.cmx
 
-poly: cmi/jCHXClassPoly.cmi cmx/jCHXClassPoly.cmx $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(JCHLIB)/jchlib.cmxa $(JCHPRE)/jchpre.cmxa
-	$(CAMLBUILDPOLY) -o chj_invariants cmx/jCHXClassPoly.cmx
+chj_invariants: cmi/jCHXClassPoly.cmi cmx/jCHXClassPoly.cmx $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(JCHLIB)/jchlib.cmxa $(JCHPRE)/jchpre.cmxa
+	$(CAMLBUILDPOLY) -o $@ cmx/jCHXClassPoly.cmx
 
-pattern: cmi/jCHXCollectPatterns.cmi cmx/jCHXCollectPatterns.cmx  $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(JCHLIB)/jchlib.cmxa $(JCHPRE)/jchpre.cmxa
-	$(CAMLBUILD) -o chj_patterns cmx/jCHXCollectPatterns.cmx
+chj_patterns: cmi/jCHXCollectPatterns.cmi cmx/jCHXCollectPatterns.cmx  $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(JCHLIB)/jchlib.cmxa $(JCHPRE)/jchpre.cmxa
+	$(CAMLBUILD) -o $@ cmx/jCHXCollectPatterns.cmx
 
-cmi/%.cmi: %.mli
+cmi/%.cmi: %.mli make_dirs
 	$(CAMLC) -o $@ -c $<
 
-cmx/jCHXClassPoly.cmx: jCHXClassPoly.ml
+cmx/jCHXClassPoly.cmx: jCHXClassPoly.ml make_dirs
 	$(CAMLCPOLY)  -o $@ -c $<
 
-cmx/%.cmx: %.ml
+cmx/%.cmx: %.ml make_dirs
 	$(CAMLC) -o $@ -c $<
 
 cleanjava:
 	rm -f *.class
 
 clean:
+	rm -f .depend
 	rm -f */*.cmx
 	rm -f */*.cmi
 	rm -f */*.o
@@ -117,3 +120,9 @@ clean:
 	rm -f chj_patterns
 	rm -f chj_invariants
 
+.depend:
+	$(OCAMLDEP) *.mli *.ml | sed "s|[^\t ]\+\.cmx|cmx/\0|" | sed "s|[^\t ]\+\.cmi|cmi/\0|" > .depend
+
+include .depend
+
+.PHONY: all make_dirs doc clean cleanjava

--- a/CodeHawk/CHJ/jchpoly/Makefile
+++ b/CodeHawk/CHJ/jchpoly/Makefile
@@ -19,6 +19,8 @@ CAMLC := ocamlopt -I +str -I +unix -I cmi -I cmx \
 	-I $(JCHPRE)/cmi \
 	-I $(JCHSYS)/cmi \
 
+OCAMLDEP := ocamldep
+
 
 MLIS := \
         jCHAnalysisUtils \
@@ -70,23 +72,24 @@ SOURCES := \
 
 OBJECTS := $(addprefix cmx/,$(SOURCES:%=%.cmx))
 
-all: make_dirs jchpoly
+all: jchpoly.cmxa
 
 make_dirs:
 	@mkdir -p cmx
 	@mkdir -p cmi
 
 
-jchpoly: $(CMIS) $(OBJECTS) $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(JCHLIB)/jchlib.cmxa $(JCHPRE)/jchpre.cmxa $(JCHSYS)/jchsys.cmxa
-	$(CAMLC) -a -o jchpoly.cmxa $(OBJECTS)
+jchpoly.cmxa: $(CMIS) $(OBJECTS) $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(JCHLIB)/jchlib.cmxa $(JCHPRE)/jchpre.cmxa $(JCHSYS)/jchsys.cmxa
+	$(CAMLC) -a -o $@ $(OBJECTS)
 
-cmi/%.cmi: %.mli
+cmi/%.cmi: %.mli make_dirs
 	$(CAMLC) -o $@ -c -opaque $<
 
-cmx/%.cmx: %.ml
+cmx/%.cmx: %.ml make_dirs
 	$(CAMLC) -o $@ -c $<
 
 clean:
+	rm -f .depend
 	rm -f */*.cmx
 	rm -f */*.cmi
 	rm -f */*.o
@@ -94,3 +97,10 @@ clean:
 	rm -f *.a
 	rm -f *.cmxa
 	rm -f Makefile~	
+
+.depend:
+	$(OCAMLDEP) *.mli *.ml | sed "s|[^\t ]\+\.cmx|cmx/\0|" | sed "s|[^\t ]\+\.cmi|cmi/\0|" > .depend
+
+include .depend
+
+.PHONY: all make_dirs doc clean

--- a/CodeHawk/CHJ/jchpre/Makefile
+++ b/CodeHawk/CHJ/jchpre/Makefile
@@ -14,6 +14,8 @@ CAMLC := ocamlopt -I +str -I +unix -I cmi -I cmx \
 	-I $(CHUTIL)/cmi \
 	-I $(JCHLIB)/cmi \
 
+OCAMLDEP := ocamldep
+
 MLIS = \
 	jCHPreAPI \
 	jCHUserData \
@@ -117,22 +119,23 @@ SOURCES = \
 
 OBJECTS := $(addprefix cmx/,$(SOURCES:%=%.cmx))
 
-all: make_dirs jchpre
+all: jchpre.cmxa
 
 make_dirs:
 	@mkdir -p cmx
 	@mkdir -p cmi
 
-jchpre: $(CMIS) $(OBJECTS) $(CHLIB)/chlib.cmxa $(ZIPLIB)/zip.cmxa $(CHUTIL)/chutil.cmxa $(JCHLIB)/jchlib.cmxa
-	$(CAMLC) -a -o jchpre.cmxa $(OBJECTS)
+jchpre.cmxa: $(CMIS) $(OBJECTS) $(CHLIB)/chlib.cmxa $(ZIPLIB)/zip.cmxa $(CHUTIL)/chutil.cmxa $(JCHLIB)/jchlib.cmxa
+	$(CAMLC) -a -o $@ $(OBJECTS)
 
-cmi/%.cmi: %.mli
+cmi/%.cmi: %.mli make_dirs
 	$(CAMLC) -o $@ -c -opaque $<
 
-cmx/%.cmx: %.ml
+cmx/%.cmx: %.ml make_dirs
 	$(CAMLC) -o $@ -c $<
 
 clean:
+	rm -f .depend
 	rm -f */*.cmx
 	rm -f */*.cmi
 	rm -f */*.o
@@ -141,3 +144,9 @@ clean:
 	rm -f *.cmxa
 	rm -f Makefile~	
 
+.depend:
+	$(OCAMLDEP) *.mli *.ml | sed "s|[^\t ]\+\.cmx|cmx/\0|" | sed "s|[^\t ]\+\.cmi|cmi/\0|" > .depend
+
+include .depend
+
+.PHONY: all make_dirs doc clean

--- a/CodeHawk/CHJ/jchstac/Makefile
+++ b/CodeHawk/CHJ/jchstac/Makefile
@@ -64,36 +64,38 @@ CAMLPREBUILD := ocamlopt str.cmxa unix.cmxa \
 	$(JCHLIB)/jchlib.cmxa \
 	$(JCHPRE)/jchpre.cmxa \
 
+OCAMLDEP := ocamldep
 
-all: make_dirs initialize classinvariants translateclass
+all: chj_initialize chj_class_invariants chj_translate_class
 
 make_dirs:
 	@mkdir -p cmx
 	@mkdir -p cmi
 
-initialize: cmi/jCHVersion.cmi cmx/jCHVersion.cmx cmi/jCHXInitializeAnalysis.cmi cmx/jCHXInitializeAnalysis.cmx $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(JCHLIB)/jchlib.cmxa $(JCHPRE)/jchpre.cmxa
+chj_initialize: cmi/jCHVersion.cmi cmx/jCHVersion.cmx cmi/jCHXInitializeAnalysis.cmi cmx/jCHXInitializeAnalysis.cmx $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(JCHLIB)/jchlib.cmxa $(JCHPRE)/jchpre.cmxa
 	$(CAMLBUILD) -o chj_initialize cmx/jCHVersion.cmx cmx/jCHXInitializeAnalysis.cmx
 
-classinvariants: cmi/jCHXClassInvariants.cmi cmx/jCHXClassInvariants.cmx $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(JCHLIB)/jchlib.cmxa $(JCHPRE)/jchpre.cmxa
-	$(CAMLBUILD) -o chj_class_invariants cmx/jCHXClassInvariants.cmx
+chj_class_invariants: cmi/jCHXClassInvariants.cmi cmx/jCHXClassInvariants.cmx $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(JCHLIB)/jchlib.cmxa $(JCHPRE)/jchpre.cmxa
+	$(CAMLBUILD) -o $@ cmx/jCHXClassInvariants.cmx
 
-translateclass: cmi/jCHXTranslateClass.cmi cmx/jCHXTranslateClass.cmx $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(JCHLIB)/jchlib.cmxa $(JCHPRE)/jchpre.cmxa
-	$(CAMLPREBUILD) -o chj_translate_class cmx/jCHXTranslateClass.cmx
+chj_translate_class: cmi/jCHXTranslateClass.cmi cmx/jCHXTranslateClass.cmx $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(JCHLIB)/jchlib.cmxa $(JCHPRE)/jchpre.cmxa
+	$(CAMLPREBUILD) -o $@ cmx/jCHXTranslateClass.cmx
 
-usertemplate: cmi/jCHXTemplate.cmi cmx/jCHXTemplate.cmx $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(JCHLIB)/jchlib.cmxa $(JCHPRE)/jchpre.cmxa
-	$(CAMLBUILD) -o chj_template cmx/jCHXTemplate.cmx
+chj_template: cmi/jCHXTemplate.cmi cmx/jCHXTemplate.cmx $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(JCHLIB)/jchlib.cmxa $(JCHPRE)/jchpre.cmxa
+	$(CAMLBUILD) -o $@ cmx/jCHXTemplate.cmx
 
 
-cmi/%.cmi: %.mli
+cmi/%.cmi: %.mli make_dirs
 	$(CAMLC) $(INCLUDES) -o $@ -c $<
 
-cmx/%.cmx: %.ml
+cmx/%.cmx: %.ml make_dirs
 	$(CAMLC) $(INCLUDES) -o $@ -c $<
 
 cleanjava:
 	rm -f *.class
 
 clean:
+	rm -f .depend
 	rm -f */*.cmx
 	rm -f */*.cmi
 	rm -f */*.o
@@ -107,3 +109,10 @@ clean:
 	rm -f chj_translate_class
 	rm -f chj_class_invariants
 	rm -f .depend
+
+.depend:
+	$(OCAMLDEP) *.mli *.ml | sed "s|[^\t ]\+\.cmx|cmx/\0|" | sed "s|[^\t ]\+\.cmi|cmi/\0|" > .depend
+
+include .depend
+
+.PHONY: all make_dirs doc clean

--- a/CodeHawk/CHJ/jchsys/Makefile
+++ b/CodeHawk/CHJ/jchsys/Makefile
@@ -17,6 +17,7 @@ CAMLC := ocamlopt -I +str -I cmi -I cmx \
 	-I $(JCHLIB)/cmi \
 	-I $(JCHPRE)/cmi \
 
+OCAMLDEP := ocamldep
 
 MLIS := \
         jCHGlobals \
@@ -62,23 +63,24 @@ SOURCES := \
 
 OBJECTS := $(addprefix cmx/,$(SOURCES:%=%.cmx))
 
-all: make_dirs jchsys
+all: jchsys.cmxa
 
 make_dirs:
 	@mkdir -p cmx
 	@mkdir -p cmi
 
 
-jchsys: $(CMIS) $(OBJECTS) $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(JCHLIB)/jchlib.cmxa $(JCHPRE)/jchpre.cmxa
-	$(CAMLC) -a -o jchsys.cmxa $(OBJECTS)
+jchsys.cmxa: $(CMIS) $(OBJECTS) $(CHLIB)/chlib.cmxa $(CHUTIL)/chutil.cmxa $(JCHLIB)/jchlib.cmxa $(JCHPRE)/jchpre.cmxa
+	$(CAMLC) -a -o $@ $(OBJECTS)
 
-cmi/%.cmi: %.mli
+cmi/%.cmi: %.mli make_dirs
 	$(CAMLC) -o $@ -c -opaque $<
 
-cmx/%.cmx: %.ml
+cmx/%.cmx: %.ml make_dirs
 	$(CAMLC) -o $@ -c $<
 
 clean:
+	rm -f .depend
 	rm -f */*.cmx
 	rm -f */*.cmi
 	rm -f */*.o
@@ -86,3 +88,10 @@ clean:
 	rm -f *.a
 	rm -f *.cmxa
 	rm -f Makefile~	
+
+.depend:
+	$(OCAMLDEP) *.mli *.ml | sed "s|[^\t ]\+\.cmx|cmx/\0|" | sed "s|[^\t ]\+\.cmi|cmi/\0|" > .depend
+
+include .depend
+
+.PHONY: all make_dirs doc clean

--- a/CodeHawk/full_make_no_gui.sh
+++ b/CodeHawk/full_make_no_gui.sh
@@ -1,29 +1,29 @@
 #!/bin/bash
 set -e
-make -C CH/chlib
-make -C CH/chutil
-make -C CH/xprlib
-make -C CHC/cchcil
-make -C CHC/cchlib
-make -C CHC/cchpre
-make -C CHC/cchanalyze
-make -C CHC/cchcmdline
-make -C CHB/bchlib
-make -C CHB/bchcil
-make -C CHB/bchlibpe
-make -C CHB/bchlibelf
-make -C CHB/bchlibx86
-make -C CHB/bchlibmips32
-make -C CHB/bchlibarm32
-make -C CHB/bchlibpower32
-make -C CHB/bchanalyze
-make -C CHB/bchcmdline
-make -C CHJ/jchlib
-make -C CHJ/jchpre
-make -C CHJ/jchsys
-make -C CHJ/jchpoly
-make -C CHJ/jchfeatures
-make -C CHJ/jchmuse
-make -C CHJ/jchcost
-make -C CHJ/jchcmdline
-make -C CHJ/jchstac
+make -C CH/chlib -j$(nproc)
+make -C CH/chutil -j$(nproc)
+make -C CH/xprlib -j$(nproc)
+make -C CHC/cchcil -j$(nproc)
+make -C CHC/cchlib -j$(nproc)
+make -C CHC/cchpre -j$(nproc)
+make -C CHC/cchanalyze -j$(nproc)
+make -C CHC/cchcmdline -j$(nproc)
+make -C CHB/bchlib -j$(nproc)
+make -C CHB/bchcil -j$(nproc)
+make -C CHB/bchlibpe -j$(nproc)
+make -C CHB/bchlibelf -j$(nproc)
+make -C CHB/bchlibx86 -j$(nproc)
+make -C CHB/bchlibmips32 -j$(nproc)
+make -C CHB/bchlibarm32 -j$(nproc)
+make -C CHB/bchlibpower32 -j$(nproc)
+make -C CHB/bchanalyze -j$(nproc)
+make -C CHB/bchcmdline -j$(nproc)
+make -C CHJ/jchlib -j$(nproc)
+make -C CHJ/jchpre -j$(nproc)
+make -C CHJ/jchsys -j$(nproc)
+make -C CHJ/jchpoly -j$(nproc)
+make -C CHJ/jchfeatures -j$(nproc)
+make -C CHJ/jchmuse -j$(nproc)
+make -C CHJ/jchcost -j$(nproc)
+make -C CHJ/jchcmdline -j$(nproc)
+make -C CHJ/jchstac -j$(nproc)


### PR DESCRIPTION
- Support parallel make with `make -j`
- Lift requirement that `MLIS` and `SOURCES` lists are ordered

`full_make_no_gui.sh` now takes 26 seconds on my machine, down from 57 seconds before this change.

Unrelated improvements:

- Rename executable targets to match the executable filenames
- Mark non-file targets as `.PHONY`