### PR TITLE
Rigorous dune dependencies

### DIFF
--- a/CodeHawk/CH/chlib/dune
+++ b/CodeHawk/CH/chlib/dune
@@ -1,5 +1,5 @@
 (library
   (name chlib)
-  (libraries str unix zarith)
+  (libraries unix zarith)
   (public_name codehawk.chlib)
   (wrapped false))

--- a/CodeHawk/CH/chutil/dune
+++ b/CodeHawk/CH/chutil/dune
@@ -1,6 +1,6 @@
 (library
   (name chutil)
-  (libraries chlib extlib str unix zarith)
+  (libraries chlib extlib zarith)
   (public_name codehawk.chutil)
   (wrapped false))
 

--- a/CodeHawk/CHB/bchanalyze/dune
+++ b/CodeHawk/CHB/bchanalyze/dune
@@ -1,6 +1,6 @@
 (library
   (name bchanalyze)
-  (libraries bchlib bchlibarm32 bchlibelf bchlibmips32 bchlibpe bchlibpower32 bchlibx86 chlib chutil extlib zarith)
+  (libraries bchlib bchlibarm32 bchlibmips32 bchlibpe bchlibpower32 bchlibx86 chlib chutil extlib xprlib)
   (public_name codehawk.bchanalyze)
   (wrapped false))
 

--- a/CodeHawk/CHB/bchcil/dune
+++ b/CodeHawk/CHB/bchcil/dune
@@ -1,6 +1,6 @@
 (library
   (name bchcil)
-  (libraries bchlib chlib chutil extlib goblint-cil xprlib zarith zip)
+  (libraries bchlib chlib chutil goblint-cil)
   (public_name codehawk.bchcil)
   (wrapped false))
 

--- a/CodeHawk/CHB/bchcmdline/dune
+++ b/CodeHawk/CHB/bchcmdline/dune
@@ -1,20 +1,20 @@
 (executable
   (name bCHXBinaryAnalyzer)
-  (libraries bchanalyze bchcil bchlib bchlibarm32 bchlibmips32 bchlibpe bchlibpower32 bchlibx86 chlib chutil goblint-cil zip)
+  (libraries bchanalyze bchcil bchlib bchlibarm32 bchlibelf bchlibmips32 bchlibpe bchlibpower32 bchlibx86 chlib chutil extlib)
   (modules bCHXBinaryAnalyzer)
   (package exes)
   (public_name chx86_analyze))
 
 (executable
   (name bCHXInspectSummaries)
-  (libraries bchlib bchlibpe chlib chutil zip)
+  (libraries bchlib chlib chutil)
   (modules bCHXInspectSummaries)
   (package exes)
   (public_name chx86_inspect_summaries))
 
 (executable
   (name bCHXSaveExports)
-  (libraries bchlib bchlibpe bchlibx86 chlib chutil zip)
+  (libraries bchlib bchlibpe bchlibx86 chlib chutil)
   (modules bCHXSaveExports)
   (package exes)
   (public_name chx86_save_exports))

--- a/CodeHawk/CHB/bchlib/dune
+++ b/CodeHawk/CHB/bchlib/dune
@@ -1,6 +1,6 @@
 (library
   (name bchlib)
-  (libraries chlib chutil extlib str unix xprlib zarith zip)
+  (libraries chlib chutil extlib xprlib zarith zip)
   (modules_without_implementation bCHJavaBasicTypes)
   (public_name codehawk.bchlib)
   (wrapped false))

--- a/CodeHawk/CHB/bchlibarm32/dune
+++ b/CodeHawk/CHB/bchlibarm32/dune
@@ -1,6 +1,6 @@
 (library
   (name bchlibarm32)
-  (libraries bchcil bchlib bchlibelf chlib chutil extlib xprlib zarith)
+  (libraries bchlib bchlibelf chlib chutil extlib xprlib)
   (public_name codehawk.bchlibarm32)
   (wrapped false))
 

--- a/CodeHawk/CHB/bchlibelf/dune
+++ b/CodeHawk/CHB/bchlibelf/dune
@@ -1,6 +1,6 @@
 (library
   (name bchlibelf)
-  (libraries bchcil bchlib bchlibpe chlib chutil extlib xprlib)
+  (libraries bchlib bchlibpe chlib chutil extlib)
   (modules :standard \ bCHDebugARangesSection)
   (public_name codehawk.bchlibelf)
   (wrapped false))

--- a/CodeHawk/CHB/bchlibmips32/dune
+++ b/CodeHawk/CHB/bchlibmips32/dune
@@ -1,6 +1,6 @@
 (library
   (name bchlibmips32)
-  (libraries bchlib bchlibelf chlib chutil extlib xprlib zarith)
+  (libraries bchlib bchlibelf chlib chutil extlib xprlib)
   (public_name codehawk.bchlibmips32)
   (wrapped false))
 

--- a/CodeHawk/CHB/bchlibpe/dune
+++ b/CodeHawk/CHB/bchlibpe/dune
@@ -1,6 +1,6 @@
 (library
   (name bchlibpe)
-  (libraries bchlib chlib chutil extlib xprlib)
+  (libraries bchlib chlib chutil extlib str)
   (public_name codehawk.bchlibpe)
   (wrapped false))
 

--- a/CodeHawk/CHB/bchlibpower32/dune
+++ b/CodeHawk/CHB/bchlibpower32/dune
@@ -1,6 +1,6 @@
 (library
   (name bchlibpower32)
-  (libraries bchcil bchlib bchlibelf chlib chutil extlib xprlib zarith)
+  (libraries bchlib bchlibelf chlib chutil extlib xprlib)
   (public_name codehawk.bchlibpower32)
   (wrapped false))
 

--- a/CodeHawk/CHB/bchlibx86/dune
+++ b/CodeHawk/CHB/bchlibx86/dune
@@ -1,6 +1,6 @@
 (library
   (name bchlibx86)
-  (libraries bchlib bchcil bchlibelf bchlibpe chlib chutil xprlib)
+  (libraries bchlib bchlibpe bchlibelf chlib chutil extlib xprlib zarith)
   (public_name codehawk.bchlibx86)
   (wrapped false))
 

--- a/CodeHawk/CHC/cchanalyze/dune
+++ b/CodeHawk/CHC/cchanalyze/dune
@@ -1,6 +1,6 @@
 (library
   (name cchanalyze)
-  (libraries cchlib cchpre chlib chutil extlib xprlib zarith)
+  (libraries cchlib cchpre chlib chutil xprlib zarith)
   (modules_without_implementation cCHCommon)
   (public_name codehawk.cchanalyze)
   (wrapped false))

--- a/CodeHawk/CHC/cchcil/dune
+++ b/CodeHawk/CHC/cchcil/dune
@@ -1,13 +1,13 @@
 (library
   (name cchcil)
-  (libraries chlib chutil extlib goblint-cil zarith)
+  (libraries chutil goblint-cil)
   (modules :standard \ cCHXParseFile)
   (public_name codehawk.cchcil)
   (wrapped false))
 
 (executable
   (name cCHXParseFile)
-  (libraries cchcil chlib chutil extlib goblint-cil zarith)
+  (libraries cchcil chlib chutil goblint-cil)
   (modules cCHXParseFile)
   (package exes)
   (public_name parseFile))

--- a/CodeHawk/CHC/cchcmdline/dune
+++ b/CodeHawk/CHC/cchcmdline/dune
@@ -1,13 +1,13 @@
 (executable
   (name cCHXInspectSummaries)
-  (libraries chlib cchlib cchpre)
+  (libraries cchlib chlib chutil)
   (modules cCHXInspectSummaries)
   (package exes)
   (public_name inspectsummaries))
 
 (executable
   (name cCHXCAnalyzer)
-  (libraries chlib cchlib cchpre cchanalyze)
+  (libraries cchlib cchpre cchanalyze chlib chutil)
   (modules cCHXCAnalyzer cCHVersion)
   (package exes)
   (public_name canalyzer))

--- a/CodeHawk/CHC/cchpre/dune
+++ b/CodeHawk/CHC/cchpre/dune
@@ -1,6 +1,6 @@
 (library
   (name cchpre)
-  (libraries cchlib chlib chutil str xprlib)
+  (libraries cchlib chlib chutil xprlib)
   (public_name codehawk.cchpre)
   (wrapped false))
 

--- a/CodeHawk/CHJ/jchcmdline/dune
+++ b/CodeHawk/CHJ/jchcmdline/dune
@@ -1,6 +1,6 @@
 (executable
   (name jCHXClassExperiment)
-  (libraries chlib chutil jchlib jchpre)
+  (libraries chlib jchlib jchpre)
   (modules jCHXClassExperiment)
   (package exes)
   (public_name chj_experiment))

--- a/CodeHawk/CHJ/jchcost/dune
+++ b/CodeHawk/CHJ/jchcost/dune
@@ -1,6 +1,6 @@
 (library
   (name jchcost)
-  (libraries chlib chutil extlib jchlib jchpoly jchpre jchsys)
+  (libraries chlib chutil jchlib jchpoly jchpre jchsys zarith)
   (public_name codehawk.jchcost)
   (wrapped false))
 

--- a/CodeHawk/CHJ/jchfeatures/dune
+++ b/CodeHawk/CHJ/jchfeatures/dune
@@ -1,6 +1,6 @@
 (library
   (name jchfeatures)
-  (libraries chlib chutil jchlib jchpre)
+  (libraries chlib chutil extlib jchlib jchpre)
   (public_name codehawk.jchfeatures)
   (wrapped false))
 

--- a/CodeHawk/CHJ/jchlib/dune
+++ b/CodeHawk/CHJ/jchlib/dune
@@ -1,6 +1,6 @@
 (library
   (name jchlib)
-  (libraries chlib chutil extlib zarith zip)
+  (libraries chlib chutil extlib str zarith zip)
   (public_name codehawk.jchlib)
   (wrapped false))
 

--- a/CodeHawk/CHJ/jchmuse/dune
+++ b/CodeHawk/CHJ/jchmuse/dune
@@ -1,20 +1,20 @@
 (executable
   (name jCHXExtractFeatures)
-  (libraries chlib chutil jchlib jchfeatures jchpre)
+  (libraries chlib chutil extlib jchlib jchfeatures jchpre)
   (modules jCHXExtractFeatures)
   (package exes)
   (public_name chj_features))
 
 (executable
   (name jCHXExtractExprFeatures)
-  (libraries chlib chutil jchlib jchfeatures jchpre)
+  (libraries chlib chutil extlib jchlib jchfeatures jchpre)
   (modules jCHXExtractExprFeatures)
   (package exes)
   (public_name chj_efeatures))
 
 (executable
   (name jCHXClassPoly)
-  (libraries chlib chutil jchlib jchpoly jchpre jchsys)
+  (libraries chlib chutil extlib jchlib jchpoly jchpre jchsys)
   (modules jCHXClassPoly)
   (package exes)
   (public_name chj_invariants))

--- a/CodeHawk/CHJ/jchpoly/dune
+++ b/CodeHawk/CHJ/jchpoly/dune
@@ -1,6 +1,6 @@
 (library
   (name jchpoly)
-  (libraries chlib chutil jchlib jchpre jchsys)
+  (libraries chlib chutil jchlib jchpre jchsys zarith)
   (public_name codehawk.jchpoly)
   (wrapped false))
 

--- a/CodeHawk/CHJ/jchstac/dune
+++ b/CodeHawk/CHJ/jchstac/dune
@@ -1,27 +1,27 @@
 (executable
   (name jCHXInitializeAnalysis)
-  (libraries chlib chutil jchcost jchlib jchpre jchpoly)
+  (libraries chlib chutil jchcost jchlib jchpre jchpoly jchsys)
   (modules jCHVersion jCHXInitializeAnalysis)
   (package exes)
   (public_name chj_initialize))
 
 (executable
   (name jCHXClassInvariants)
-  (libraries chlib chutil jchlib jchpoly jchpre jchsys)
+  (libraries chlib chutil extlib jchlib jchpoly jchpre jchsys)
   (modules jCHXClassInvariants)
   (package exes)
   (public_name chj_class_invariants))
 
 (executable
   (name jCHXTranslateClass)
-  (libraries chlib chutil jchlib jchpre)
+  (libraries chlib chutil extlib jchlib jchpre)
   (modules jCHXTranslateClass)
   (package exes)
   (public_name chj_translate_class))
 
 (executable
   (name jCHXTemplate)
-  (libraries chlib chutil jchlib jchpre)
+  (libraries chlib jchlib jchpre)
   (modules jCHXTemplate)
   (package exes)
   (public_name chj_usertemplate))

--- a/CodeHawk/CHJ/jchsys/dune
+++ b/CodeHawk/CHJ/jchsys/dune
@@ -1,6 +1,6 @@
 (library
   (name jchsys)
-  (libraries chlib chutil extlib jchlib jchpre str zarith)
+  (libraries chlib chutil jchlib jchpre zarith)
   (public_name codehawk.jchsys)
   (wrapped false))
 

--- a/CodeHawk/CHT/CHB_tests/bchlib_tests/tbchlib/dune
+++ b/CodeHawk/CHT/CHB_tests/bchlib_tests/tbchlib/dune
@@ -1,6 +1,6 @@
 (library
   (name tbchlib)
-  (libraries bchlib chlib chutil extlib tchlib xprlib zarith zip)
+  (libraries bchlib chlib chutil tchlib)
   (public_name codehawk.tbchlib)
   (wrapped false))
 

--- a/CodeHawk/CHT/CHB_tests/bchlib_tests/txbchlib/dune
+++ b/CodeHawk/CHT/CHB_tests/bchlib_tests/txbchlib/dune
@@ -1,6 +1,6 @@
 (tests 
   (names bCHDoublewordTest bCHImmediateTest bCHLocationTest bCHStreamWrapperTest)
-  (libraries bchlib chlib chutil extlib tbchlib tchlib txprlib xprlib zarith))
+  (libraries bchlib chlib chutil tbchlib tchlib))
 
 (env
   (dev

--- a/CodeHawk/CHT/CHB_tests/bchlibarm32_tests/tbchlibarm32/dune
+++ b/CodeHawk/CHT/CHB_tests/bchlibarm32_tests/tbchlibarm32/dune
@@ -1,5 +1,5 @@
 (library
   (name tbchlibarm32)
-  (libraries bchlib bchlibarm32 chlib chutil extlib tbchlib tchlib xprlib zarith zip)
+  (libraries bchlib bchlibarm32 chutil tbchlib tchlib xprlib)
   (public_name codehawk.tbchlibarm32)
   (wrapped false))

--- a/CodeHawk/CHT/CHB_tests/bchlibarm32_tests/txbchlibarm32/dune
+++ b/CodeHawk/CHT/CHB_tests/bchlibarm32_tests/txbchlibarm32/dune
@@ -9,4 +9,4 @@
     bCHTranslateARMToCHIFTest
     bCHARMAssemblyFunctionTest
     bCHFnARMDictionaryTest)
-  (libraries bchanalyze bchcil bchlibarm32 chlib chutil extlib tbchlib tbchlibarm32 tchlib txprlib xprlib zarith))
+  (libraries bchanalyze bchlib bchlibarm32 chlib chutil tbchlib tbchlibarm32 tchlib zarith))

--- a/CodeHawk/CHT/CHB_tests/bchlibelf_tests/tbchlibelf/dune
+++ b/CodeHawk/CHT/CHB_tests/bchlibelf_tests/tbchlibelf/dune
@@ -1,6 +1,6 @@
 (library
   (name tbchlibelf)
-  (libraries bchlib bchlibelf chlib chutil extlib tchlib xprlib zarith zip)
+  (libraries bchlib bchlibelf tchlib)
   (public_name codehawk.tbchlibelf)
   (wrapped false))
 

--- a/CodeHawk/CHT/CHB_tests/bchlibelf_tests/txbchlibelf/dune
+++ b/CodeHawk/CHT/CHB_tests/bchlibelf_tests/txbchlibelf/dune
@@ -1,6 +1,6 @@
 (tests 
   (names bCHDwarfTest bCHELFDebugAbbrevSectionTest bCHELFDebugLocSectionTest)
-  (libraries bchlib bchlibelf chlib chutil extlib tbchlib tbchlibelf tchlib txprlib xprlib zarith))
+  (libraries bchlib bchlibelf chlib chutil tbchlibelf tchlib))
 
 (env
   (dev

--- a/CodeHawk/CHT/CHB_tests/bchlibmips32_tests/txbchlibmips32/dune
+++ b/CodeHawk/CHT/CHB_tests/bchlibmips32_tests/txbchlibmips32/dune
@@ -1,6 +1,6 @@
 (tests 
   (names bCHAssembleMIPSInstructionTest bCHDisassembleMIPSInstructionTest)
-  (libraries bchlib bchlibmips32 chlib chutil extlib tbchlib tchlib txprlib xprlib zarith))
+  (libraries bchlib bchlibmips32 chlib chutil tchlib))
 
 (env
   (dev

--- a/CodeHawk/CHT/CHB_tests/bchlibpower32_tests/txbchlibpower32/dune
+++ b/CodeHawk/CHT/CHB_tests/bchlibpower32_tests/txbchlibpower32/dune
@@ -1,6 +1,6 @@
 (tests 
   (names bCHDisassemblePowerInstructionTest bCHDisassembleVLEInstructionTest)
-  (libraries bchlib bchlibpower32 chlib chutil extlib tbchlib tchlib txprlib xprlib zarith))
+  (libraries bchlib bchlibpower32 chlib chutil tchlib))
 
 (env
   (dev

--- a/CodeHawk/CHT/CHB_tests/bchlibx86_tests/tbchlibx86/dune
+++ b/CodeHawk/CHT/CHB_tests/bchlibx86_tests/tbchlibx86/dune
@@ -1,6 +1,6 @@
 (library
   (name tbchlibx86)
-  (libraries bchlib bchlibx86 chlib chutil extlib tchlib tbchlib zarith zip)
+  (libraries bchlib chlib chutil tchlib xprlib)
   (public_name codehawk.tbchlibx86)
   (wrapped false))
 

--- a/CodeHawk/CHT/CHB_tests/bchlibx86_tests/txbchlibx86/dune
+++ b/CodeHawk/CHT/CHB_tests/bchlibx86_tests/txbchlibx86/dune
@@ -1,6 +1,6 @@
 (tests 
   (names bCHDisassembleInstructionTest bCHDisassembleX0Test)
-  (libraries bchlib bchlibx86 chlib chutil extlib tbchlib tbchlibx86 tchlib txprlib xprlib zarith))
+  (libraries bchlib bchlibx86 chlib chutil tchlib))
 
 (env
   (dev

--- a/CodeHawk/CHT/CH_tests/xprlib_tests/txprlib/dune
+++ b/CodeHawk/CHT/CH_tests/xprlib_tests/txprlib/dune
@@ -1,6 +1,6 @@
 (library
   (name txprlib)
-  (libraries chlib chutil extlib tchlib xprlib zarith)
+  (libraries chlib chutil tchlib xprlib)
   (public_name codehawk.txprlib)
   (wrapped false))
 

--- a/CodeHawk/CHT/CH_tests/xprlib_tests/txxprlib/dune
+++ b/CodeHawk/CHT/CH_tests/xprlib_tests/txxprlib/dune
@@ -1,6 +1,6 @@
 (tests 
   (names xconsequenceTest xsimplifyTest)
-  (libraries chlib chutil extlib tchlib txprlib xprlib zarith))
+  (libraries tchlib txprlib xprlib))
 
 (env
   (dev

--- a/CodeHawk/CHT/tchlib/dune
+++ b/CodeHawk/CHT/tchlib/dune
@@ -1,6 +1,6 @@
 (library
   (name tchlib)
-  (libraries chlib chutil extlib zip)
+  (libraries chlib chutil)
   (public_name codehawk.tchlib)
   (wrapped false))
 

--- a/CodeHawk/dune-project
+++ b/CodeHawk/dune-project
@@ -1,4 +1,6 @@
 (lang dune 3.11)
 
+(implicit_transitive_deps false)
+
 (package (name codehawk))
 (package (name exes))


### PR DESCRIPTION
Added `(implicit_transitive_deps false)` to the project, which means that libraries will not be able to `open` modules from unlisted dependencies.

Also did a pass through `dune` files to remove dependencies that were not necessary to build, i.e. nothing from them was `open`ed. Transitive dependencies still don't have to be mentioned for linking.