### PR TITLE
Teach Printexc how to print BCH_failure exceptions

### DIFF
--- a/CodeHawk/CHB/bchlib/bCHBCTypeUtil.ml
+++ b/CodeHawk/CHB/bchlib/bCHBCTypeUtil.ml
@@ -41,6 +41,16 @@ open BCHBCFiles
 open BCHBCTypePretty
 open BCHBCTypes
 
+let string_printer = CHPrettyUtil.string_printer
+let p2s = string_printer#print
+
+(* Teach Printexc how to print our own exceptions *)
+let () =
+  Printexc.register_printer
+    (function
+      | BCH_failure e -> Some (p2s(e))
+      | _ -> None (* for other exceptions *)
+    )
 
 (* ====================================================== common scalar types *)
 


### PR DESCRIPTION
without this, we get cryptic error messages like:
```
BCHBasicTypes.BCH_failure(_)
```
which is not very useful for debugging. With this change, we get something like: 
```
Alignof error: tvoid
```
which is more greppable ;-)