### PR TITLE
Fix for goblint-cil 2.0.4 breakage

### DIFF
--- a/CodeHawk/CHB/bchcil/bCHCilToCBasic.ml
+++ b/CodeHawk/CHB/bchcil/bCHCilToCBasic.ml
@@ -334,8 +334,8 @@ and cil_stmtkind_to_bstmtkind (k: GoblintCil.stmtkind): bstmtkind_t =
     match s with Some stmt -> Some (stmt.sid) | _ -> None in
   match k with
   | GoblintCil.Instr l -> Instr (List.map cil_instr_to_binstr l)
-  | GoblintCil.Return (Some e, l) -> Return (Some (ce e), cl l)
-  | GoblintCil.Return (None, l) -> Return (None, cl l)
+  | GoblintCil.Return (Some e, l, _el) -> Return (Some (ce e), cl l)
+  | GoblintCil.Return (None, l, _el) -> Return (None, cl l)
   | GoblintCil.Goto (s, l) -> Goto (!s.sid, cl l)
   | GoblintCil.ComputedGoto (e, l) -> ComputedGoto (ce e, cl l)
   | GoblintCil.Break l -> Break (cl l)

--- a/CodeHawk/CHC/cchcil/cHCilWriteXml.ml
+++ b/CodeHawk/CHC/cchcil/cHCilWriteXml.ml
@@ -214,7 +214,7 @@ and write_xml_stmtkind
       write_xml_instruction_list fdecls iNode instrs;
       append [iNode]
     end
-  | Return (optX, loc) ->
+  | Return (optX, loc, _Xloc) ->
     begin
       decls#write_xml_location node loc;
       match optX with


### PR DESCRIPTION
goblint-cil's latest point release changed the API (!!), this updates the pattern match to restore compatibility.

Existing users of CodeHawk will have to do `opam update && opam upgrade goblint-cil` before recompiling CodeHawk.