### PR TITLE
Sprinkle around some library dependencies in dune files

### DIFF
--- a/CodeHawk/CH/chutil/dune
+++ b/CodeHawk/CH/chutil/dune
@@ -1,5 +1,5 @@
 (library
   (name chutil)
-  (libraries chlib extlib zarith)
+  (libraries chlib extlib unix zarith)
   (public_name codehawk.chutil)
   (wrapped false))

--- a/CodeHawk/CHB/bchanalyze/dune
+++ b/CodeHawk/CHB/bchanalyze/dune
@@ -1,5 +1,5 @@
 (library
   (name bchanalyze)
-  (libraries bchlib bchlibarm32 bchlibmips32 bchlibpe bchlibpower32 bchlibx86 chlib chutil extlib xprlib)
+  (libraries bchlib bchlibarm32 bchlibmips32 bchlibpe bchlibpower32 bchlibx86 chlib chutil extlib unix xprlib)
   (public_name codehawk.bchanalyze)
   (wrapped false))

--- a/CodeHawk/CHB/bchcmdline/dune
+++ b/CodeHawk/CHB/bchcmdline/dune
@@ -1,6 +1,6 @@
 (executable
   (name bCHXBinaryAnalyzer)
-  (libraries bchanalyze bchcil bchlib bchlibarm32 bchlibelf bchlibmips32 bchlibpe bchlibpower32 bchlibx86 chlib chutil extlib)
+  (libraries bchanalyze bchcil bchlib bchlibarm32 bchlibelf bchlibmips32 bchlibpe bchlibpower32 bchlibx86 chlib chutil extlib unix)
   (modules bCHXBinaryAnalyzer)
   (package exes)
   (public_name chx86_analyze))
@@ -14,35 +14,35 @@
 
 (executable
   (name bCHXSaveExports)
-  (libraries bchlib bchlibpe bchlibx86 chlib chutil)
+  (libraries bchlib bchlibpe bchlibx86 chlib chutil unix)
   (modules bCHXSaveExports)
   (package exes)
   (public_name chx86_save_exports))
 
 (executable
   (name bCHXMakeLibSummary)
-  (libraries bchlib chlib chutil)
+  (libraries bchlib chlib chutil unix)
   (modules bCHXMakeLibSummary)
   (package exes)
   (public_name chx86_make_lib_summary))
 
 (executable
   (name bCHXMakeAppSummary)
-  (libraries bchlib chlib chutil)
+  (libraries bchlib chlib chutil unix)
   (modules bCHXMakeAppSummary)
   (package exes)
   (public_name chx86_make_app_summary))
 
 (executable
   (name bCHXMakeConstSummary)
-  (libraries chlib chutil)
+  (libraries chlib chutil unix)
   (modules bCHXMakeConstSummary)
   (package exes)
   (public_name chx86_make_const_summary))
 
 (executable
   (name bCHXMakeStructDefinition)
-  (libraries chlib chutil)
+  (libraries chlib chutil unix)
   (modules bCHXMakeStructDefinition)
   (package exes)
   (public_name chx86_make_structdef))

--- a/CodeHawk/CHB/bchlib/dune
+++ b/CodeHawk/CHB/bchlib/dune
@@ -1,6 +1,6 @@
 (library
   (name bchlib)
-  (libraries chlib chutil extlib xprlib zarith zip)
+  (libraries chlib chutil extlib unix xprlib zarith zip)
   (modules_without_implementation bCHJavaBasicTypes)
   (public_name codehawk.bchlib)
   (wrapped false))

--- a/CodeHawk/CHB/bchlibarm32/dune
+++ b/CodeHawk/CHB/bchlibarm32/dune
@@ -1,5 +1,5 @@
 (library
   (name bchlibarm32)
-  (libraries bchlib bchlibelf chlib chutil extlib xprlib)
+  (libraries bchlib bchlibelf chlib chutil extlib str unix xprlib)
   (public_name codehawk.bchlibarm32)
   (wrapped false))

--- a/CodeHawk/CHB/bchlibmips32/dune
+++ b/CodeHawk/CHB/bchlibmips32/dune
@@ -1,5 +1,5 @@
 (library
   (name bchlibmips32)
-  (libraries bchlib bchlibelf chlib chutil extlib xprlib)
+  (libraries bchlib bchlibelf chlib chutil extlib str xprlib)
   (public_name codehawk.bchlibmips32)
   (wrapped false))

--- a/CodeHawk/CHB/bchlibx86/dune
+++ b/CodeHawk/CHB/bchlibx86/dune
@@ -1,5 +1,5 @@
 (library
   (name bchlibx86)
-  (libraries bchlib bchlibpe bchlibelf chlib chutil extlib xprlib zarith)
+  (libraries bchlib bchlibpe bchlibelf chlib chutil extlib str unix xprlib zarith)
   (public_name codehawk.bchlibx86)
   (wrapped false))

--- a/CodeHawk/CHC/cchanalyze/dune
+++ b/CodeHawk/CHC/cchanalyze/dune
@@ -1,6 +1,6 @@
 (library
   (name cchanalyze)
-  (libraries cchlib cchpre chlib chutil xprlib zarith)
+  (libraries cchlib cchpre chlib chutil unix xprlib zarith)
   (modules_without_implementation cCHCommon)
   (public_name codehawk.cchanalyze)
   (wrapped false))

--- a/CodeHawk/CHC/cchlib/dune
+++ b/CodeHawk/CHC/cchlib/dune
@@ -1,5 +1,5 @@
 (library
   (name cchlib)
-  (libraries chlib chutil extlib xprlib zarith zip)
+  (libraries chlib chutil extlib unix xprlib zarith zip)
   (public_name codehawk.cchlib)
   (wrapped false))

--- a/CodeHawk/CHJ/jchcmdline/dune
+++ b/CodeHawk/CHJ/jchcmdline/dune
@@ -28,7 +28,7 @@
 
 (executable
   (name jCHXNativeMethodSignatures)
-  (libraries chlib chutil jchlib jchpre)
+  (libraries chlib chutil jchlib jchpre unix)
   (modules jCHXNativeMethodSignatures)
   (package exes)
   (public_name chj_native))

--- a/CodeHawk/CHJ/jchcost/dune
+++ b/CodeHawk/CHJ/jchcost/dune
@@ -1,5 +1,5 @@
 (library
   (name jchcost)
-  (libraries chlib chutil jchlib jchpoly jchpre jchsys zarith)
+  (libraries chlib chutil jchlib jchpoly jchpre jchsys str unix zarith)
   (public_name codehawk.jchcost)
   (wrapped false))

--- a/CodeHawk/CHJ/jchfeatures/dune
+++ b/CodeHawk/CHJ/jchfeatures/dune
@@ -1,5 +1,5 @@
 (library
   (name jchfeatures)
-  (libraries chlib chutil extlib jchlib jchpre)
+  (libraries chlib chutil extlib jchlib jchpre str unix)
   (public_name codehawk.jchfeatures)
   (wrapped false))

--- a/CodeHawk/CHJ/jchlib/dune
+++ b/CodeHawk/CHJ/jchlib/dune
@@ -1,5 +1,5 @@
 (library
   (name jchlib)
-  (libraries chlib chutil extlib str zarith zip)
+  (libraries chlib chutil extlib str unix zarith zip)
   (public_name codehawk.jchlib)
   (wrapped false))

--- a/CodeHawk/CHJ/jchmuse/dune
+++ b/CodeHawk/CHJ/jchmuse/dune
@@ -1,20 +1,20 @@
 (executable
   (name jCHXExtractFeatures)
-  (libraries chlib chutil extlib jchlib jchfeatures jchpre)
+  (libraries chlib chutil extlib jchlib jchfeatures jchpre unix)
   (modules jCHXExtractFeatures)
   (package exes)
   (public_name chj_features))
 
 (executable
   (name jCHXExtractExprFeatures)
-  (libraries chlib chutil extlib jchlib jchfeatures jchpre)
+  (libraries chlib chutil extlib jchlib jchfeatures jchpre unix)
   (modules jCHXExtractExprFeatures)
   (package exes)
   (public_name chj_efeatures))
 
 (executable
   (name jCHXClassPoly)
-  (libraries chlib chutil extlib jchlib jchpoly jchpre jchsys)
+  (libraries chlib chutil extlib jchlib jchpoly jchpre jchsys unix)
   (modules jCHXClassPoly)
   (package exes)
   (public_name chj_invariants))

--- a/CodeHawk/CHJ/jchpoly/dune
+++ b/CodeHawk/CHJ/jchpoly/dune
@@ -1,5 +1,5 @@
 (library
   (name jchpoly)
-  (libraries chlib chutil jchlib jchpre jchsys zarith)
+  (libraries chlib chutil jchlib jchpre jchsys str unix zarith)
   (public_name codehawk.jchpoly)
   (wrapped false))

--- a/CodeHawk/CHJ/jchpre/dune
+++ b/CodeHawk/CHJ/jchpre/dune
@@ -1,5 +1,5 @@
 (library
   (name jchpre)
-  (libraries chlib chutil extlib jchlib zip)
+  (libraries chlib chutil extlib jchlib str unix zip)
   (public_name codehawk.jchpre)
   (wrapped false))

--- a/CodeHawk/CHJ/jchstac/dune
+++ b/CodeHawk/CHJ/jchstac/dune
@@ -1,20 +1,20 @@
 (executable
   (name jCHXInitializeAnalysis)
-  (libraries chlib chutil jchcost jchlib jchpre jchpoly jchsys)
+  (libraries chlib chutil jchcost jchlib jchpre jchpoly jchsys unix)
   (modules jCHVersion jCHXInitializeAnalysis)
   (package exes)
   (public_name chj_initialize))
 
 (executable
   (name jCHXClassInvariants)
-  (libraries chlib chutil extlib jchlib jchpoly jchpre jchsys)
+  (libraries chlib chutil extlib jchlib jchpoly jchpre jchsys unix)
   (modules jCHXClassInvariants)
   (package exes)
   (public_name chj_class_invariants))
 
 (executable
   (name jCHXTranslateClass)
-  (libraries chlib chutil extlib jchlib jchpre)
+  (libraries chlib chutil extlib jchlib jchpre unix)
   (modules jCHXTranslateClass)
   (package exes)
   (public_name chj_translate_class))

--- a/CodeHawk/CHJ/jchsys/dune
+++ b/CodeHawk/CHJ/jchsys/dune
@@ -1,5 +1,5 @@
 (library
   (name jchsys)
-  (libraries chlib chutil jchlib jchpre zarith)
+  (libraries chlib chutil jchlib jchpre str zarith)
   (public_name codehawk.jchsys)
   (wrapped false))

--- a/CodeHawk/CHT/CHB_tests/bchlib_tests/tbchlib/dune
+++ b/CodeHawk/CHT/CHB_tests/bchlib_tests/tbchlib/dune
@@ -1,5 +1,5 @@
 (library
   (name tbchlib)
-  (libraries bchlib chlib chutil xprlib tchlib)
+  (libraries bchlib chlib chutil xprlib unix tchlib)
   (public_name codehawk.tbchlib)
   (wrapped false))

--- a/CodeHawk/CHT/tchlib/dune
+++ b/CodeHawk/CHT/tchlib/dune
@@ -1,5 +1,5 @@
 (library
   (name tchlib)
-  (libraries chlib chutil)
+  (libraries chlib chutil unix)
   (public_name codehawk.tchlib)
   (wrapped false))


### PR DESCRIPTION
This enables a clean `dune build`, without any warnings of the form

```
File "_none_", line 1:
Alert ocaml_deprecated_auto_include:
OCaml's lib directory layout changed in 5.0. The unix subdirectory has been
automatically added to the search path, but you should add -I +unix to the
command-line to silence this alert (e.g. by adding unix to the list of
libraries in your dune file, or adding use_unix to your _tags file for
ocamlbuild, or using -package unix for ocamlfind).
```