### PR TITLE
Bump tagged versions in workflows/docs.yaml

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -18,8 +18,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: ocaml/setup-ocaml@v2
+      - uses: actions/checkout@v4
+      - uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: 4.12.1
       - name: Install dependencies with opam
@@ -34,7 +34,7 @@ jobs:
             echo "::warning title=Invalid file permissions automatically fixed::$line"
           done
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./CodeHawk/_build/default/_doc/_html
 
@@ -47,4 +47,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
The workflow had been failing because it used
`actions/upload-pages-artifact@v2` which used
`actions/upload-artifact@v3` which was decomissioned on 2025-01-30.

See: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

This also bumps the tagged versions for other actions in this workflow, with the intention of avoiding future surprises of this sort.