### PR TITLE
CHC: A number of fixes for command line arguments handling

### DIFF
--- a/CodeHawk/CHC/cchanalyze/cCHPOCheckInScope.ml
+++ b/CodeHawk/CHC/cchanalyze/cCHPOCheckInScope.ml
@@ -230,6 +230,21 @@ object (self)
     r
 
   method check_safe =
+    let safemsg = fun index arg_count -> ("command-line argument"
+                                          ^ (string_of_int index)
+                                          ^ " is guaranteed to be in scope"
+                                          ^ " for argument count "
+                                          ^ (string_of_int arg_count)) in
+    let vmsg = fun index arg_count -> ("command-line argument "
+                                       ^ (string_of_int index)
+                                       ^ " is not included in argument count of "
+                                       ^ (string_of_int arg_count)) in
+    let dmsg = fun index -> ("no invariant found for argument count; "
+                             ^ "unable to validate scope of "
+                             ^ "command-line argument "
+                             ^ (string_of_int index)) in
+
+    poq#check_command_line_argument e safemsg vmsg dmsg ||
     match invs with
     | [] ->
        begin

--- a/CodeHawk/CHC/cchanalyze/cCHPOCheckInitializedRange.ml
+++ b/CodeHawk/CHC/cchanalyze/cCHPOCheckInitializedRange.ml
@@ -320,6 +320,20 @@ object (self)
     | _ -> None
 
   method check_safe =
+    let safemsg = fun index arg_count -> ("command-line argument"
+                                          ^ (string_of_int index)
+                                          ^ " is guaranteed initialized for argument count "
+                                          ^ (string_of_int arg_count)) in
+    let vmsg = fun index arg_count -> ("command-line argument "
+                                       ^ (string_of_int index)
+                                       ^ " is not included in argument count of "
+                                       ^ (string_of_int arg_count)) in
+    let dmsg = fun index -> ("no invariant found for argument count; "
+                             ^ "unable to validate initialization of "
+                             ^ "command-line argument "
+                             ^ (string_of_int index)) in
+
+    poq#check_command_line_argument e1 safemsg vmsg dmsg ||
     match self#unsigned_length_conflict with
     | Some _ -> false
     | _ ->

--- a/CodeHawk/CHC/cchanalyze/cCHPOCheckLowerBound.ml
+++ b/CodeHawk/CHC/cchanalyze/cCHPOCheckLowerBound.ml
@@ -198,6 +198,21 @@ object (self)
           | _ -> None
 
   method check_safe =
+    let safemsg = fun index arg_count -> ("command-line argument"
+                                          ^ (string_of_int index)
+                                          ^ " is guaranteed to be valid to access"
+                                          ^ " for argument count "
+                                          ^ (string_of_int arg_count)) in
+    let vmsg = fun index arg_count -> ("command-line argument "
+                                       ^ (string_of_int index)
+                                       ^ " is not included in argument count of "
+                                       ^ (string_of_int arg_count)) in
+    let dmsg = fun index -> ("no invariant found for argument count; "
+                             ^ "unable to validate access of "
+                             ^ "command-line argument "
+                             ^ (string_of_int index)) in
+
+    poq#check_command_line_argument e safemsg vmsg dmsg ||
     match invs with
     | [] ->
        begin

--- a/CodeHawk/CHC/cchanalyze/cCHPOCheckNullTerminated.ml
+++ b/CodeHawk/CHC/cchanalyze/cCHPOCheckNullTerminated.ml
@@ -166,6 +166,21 @@ object (self)
     | _ -> None
 
   method check_safe =
+    let safemsg = fun index arg_count -> ("command-line argument"
+                                          ^ (string_of_int index)
+                                          ^ " is guaranteed to be null-termianted"
+                                          ^ " for argument count "
+                                          ^ (string_of_int arg_count)) in
+    let vmsg = fun index arg_count -> ("command-line argument "
+                                       ^ (string_of_int index)
+                                       ^ " is not included in argument count of "
+                                       ^ (string_of_int arg_count)) in
+    let dmsg = fun index -> ("no invariant found for argument count; "
+                             ^ "unable to validate null-termination of "
+                             ^ "command-line argument "
+                             ^ (string_of_int index)) in
+
+    poq#check_command_line_argument e safemsg vmsg dmsg ||
     match invs with
     | [] ->
        begin

--- a/CodeHawk/CHC/cchanalyze/cCHPOCheckPtrUpperBound.ml
+++ b/CodeHawk/CHC/cchanalyze/cCHPOCheckPtrUpperBound.ml
@@ -455,6 +455,21 @@ object (self)
                    | _ -> false) acc1 invs2) false invs1
 
   method check_safe =
+    let safemsg = fun index arg_count -> ("command-line argument"
+                                          ^ (string_of_int index)
+                                          ^ " is guaranteed to be valid to access"
+                                          ^ " for argument count "
+                                          ^ (string_of_int arg_count)) in
+    let vmsg = fun index arg_count -> ("command-line argument "
+                                       ^ (string_of_int index)
+                                       ^ " is not included in argument count of "
+                                       ^ (string_of_int arg_count)) in
+    let dmsg = fun index -> ("no invariant found for argument count; "
+                             ^ "unable to validate access of "
+                             ^ "command-line argument "
+                             ^ (string_of_int index)) in
+
+    poq#check_command_line_argument e1 safemsg vmsg dmsg ||
     match self#null_terminated_string_implies_pluspi_safe with
     | Some (deps,msg) ->
        begin

--- a/CodeHawk/CHC/cchanalyze/cCHPOCheckUpperBound.ml
+++ b/CodeHawk/CHC/cchanalyze/cCHPOCheckUpperBound.ml
@@ -181,6 +181,21 @@ object (self)
        | Some l -> self#xprlist_implies_safe inv#index l
 
   method check_safe =
+    let safemsg = fun index arg_count -> ("command-line argument"
+                                          ^ (string_of_int index)
+                                          ^ " is guaranteed to be valid to access"
+                                          ^ " for argument count "
+                                          ^ (string_of_int arg_count)) in
+    let vmsg = fun index arg_count -> ("command-line argument "
+                                       ^ (string_of_int index)
+                                       ^ " is not included in argument count of "
+                                       ^ (string_of_int arg_count)) in
+    let dmsg = fun index -> ("no invariant found for argument count; "
+                             ^ "unable to validate access of "
+                             ^ "command-line argument "
+                             ^ (string_of_int index)) in
+
+    poq#check_command_line_argument e safemsg vmsg dmsg ||
     match invs with
     | [] ->
        begin

--- a/CodeHawk/CHC/cchanalyze/cCHPOCheckValidMem.ml
+++ b/CodeHawk/CHC/cchanalyze/cCHPOCheckValidMem.ml
@@ -447,7 +447,22 @@ object (self)
     r
 
   method check_safe =
-    self#global_free
+    let safemsg = fun index arg_count -> ("command-line argument"
+                                          ^ (string_of_int index)
+                                          ^ " is guaranteed to have valid memory"
+                                          ^ " for argument count "
+                                          ^ (string_of_int arg_count)) in
+    let vmsg = fun index arg_count -> ("command-line argument "
+                                       ^ (string_of_int index)
+                                       ^ " is not included in argument count of "
+                                       ^ (string_of_int arg_count)) in
+    let dmsg = fun index -> ("no invariant found for argument count; "
+                             ^ "unable to validate memory validity of "
+                             ^ "command-line argument "
+                             ^ (string_of_int index)) in
+
+    poq#check_command_line_argument e safemsg vmsg dmsg
+    || self#global_free
     || (match invs with
         | [] -> false
         | _  ->

--- a/CodeHawk/CHC/cchpre/cCHCheckValid.ml
+++ b/CodeHawk/CHC/cchpre/cCHCheckValid.ml
@@ -1510,6 +1510,11 @@ let check_ppo_validity
        | _ -> ()
      end
 
+  | PPtrUpperBound (_, _, e, _) when is_program_name e ->
+     make
+       ("validity of pointer to program name is guaranteed by the "
+        ^ "operating system")
+
   | PPtrUpperBound (_, _, e, _) when is_null_pointer e ->
      make ("not-null of first argument is checked separately")
 
@@ -2062,6 +2067,11 @@ let check_ppo_validity
   | PInitialized (Mem e, NoOffset) when is_constant_string e ->
      make ("constant string is guaranteed to have at least one character")
 
+  | PInitializedRange (e, _) when is_program_name e ->
+     make
+       ("validity of pointer to program name is guaranteed by the "
+        ^ "operating system")
+
   | PInitializedRange (e, _) when is_null_pointer e ->
      make "null pointer does have any range, so this is trivially valid"
 
@@ -2149,6 +2159,11 @@ let check_ppo_validity
 
   | PNullTerminated (Const (CWStr _))
     | PNullTerminated (CastE (_, Const (CWStr _))) -> make "wide string literal"
+
+  | PNullTerminated e when is_program_name e ->
+     make
+       ("validity of pointer to program name is guaranteed by the "
+        ^ "operating system")
 
   | PNullTerminated e when is_null_pointer e ->
     make "null pointer is not subject to null-termination"


### PR DESCRIPTION
With these changes we no longer have a ton of open POs when programs
use command line arguments.

These fixes both issues when accessing `argv[0]` directly (which is given 
special treatment) and accessing other command line arguments after
checking that those exist (by looking at the value of `argc`). 

Before these changes, these were all the open POs for a simple hello world
program:

```
int main(int argc, char **argv) {
  if (argc != 2) {
    printf("ERROR: usage: %s <name>\n", argv[0]);
--------------------------------------------------------------------------------
|  null-terminated((*(argv + 0):((char *) *)))                                 |
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
|  initialized-range((*(argv + 0):((char *) *)), len:cnapp(ntp((*(argv + 0):((char *) *))))|
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
|  ptr-upper-bound((*(argv + 0):((char *) *)), cnapp(ntp((*(argv + 0):((char *) *))), op:pluspi, typ: char)|
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
|  Preconditions:                                                              |
|    initialized((*argv))                                                      |
--------------------------------------------------------------------------------
    return 1;
  }
  printf("Hello world %s\n", argv[1]);
--------------------------------------------------------------------------------
|  initialized-range((*(argv + 1):((char *) *)), len:cnapp(ntp((*(argv + 1):((char *) *))))|
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
|  valid-mem((*(argv + 1):((char *) *)))                                       |
|  [augv[call]:$fn-entry$(-1):calls]:none                                      |
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
|  null-terminated((*(argv + 1):((char *) *)))                                 |
|  no invariants found for *(((lval (argv) +i 1):((char*)*))                   |
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
|  upper-bound(char,(*(argv + 1):((char *) *)))                                |
|  no invariants for *(((lval (argv) +i 1):((char*)*))                         |
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
|  lower-bound(char,(*(argv + 1):((char *) *)))                                |
|  no invariants found for *(((lval (argv) +i 1):((char*)*))                   |
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
|  ptr-upper-bound((*(argv + 1):((char *) *)), cnapp(ntp((*(argv + 1):((char *) *))), op:pluspi, typ: char)|
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
|  in-scope((*(argv + 1):((char *) *)))                                        |
|  no invariants found for *(((lval (argv) +i 1):((char*)*))                   |
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
|  Preconditions:                                                              |
|    ptr-upper-bound-deref(argv, 1, op:indexpi, typ: (char *))                 |
--------------------------------------------------------------------------------
  return 0;
}
```

Two pending things which I will tackle on the next set of commits:
- There's still one open pre-condition that I haven't figured out how to
close:
```
  printf("Hello world %s\n", argv[1]);
--------------------------------------------------------------------------------
|  Preconditions:                                                              |
|    ptr-upper-bound-deref(argv, 1, op:indexpi, typ: (char *))                 |
--------------------------------------------------------------------------------
```
- If the program does not check the value of `argc` before accessing
`argv` then the diagnostics all relate to the fact that we don't have 
invariants to verify whether the access is correct or not, which makes it
sound like there's a bug in CHC. For example:
```
  printf("Hello world %s\n", argv[1]);
--------------------------------------------------------------------------------
|  upper-bound(char,(*(argv + 1):((char *) *)))                                |
|  no invariant found for argument count; unable to validate access of command-line argument 1|
|  no invariants for *(((lval (argv) +i 1):((char*)*))                         |
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
|  not-null((*(argv + 1):((char *) *)))                                        |
|  no invariant found for argument count; unable to validate not-null of command-line argument 1|
--------------------------------------------------------------------------------
```