### PR TITLE
Add `codehawk.opam` file

### DIFF
--- a/.github/workflows/dune.yaml
+++ b/.github/workflows/dune.yaml
@@ -21,7 +21,8 @@ jobs:
         ocaml-compiler: ${{ matrix.ocaml-compiler }}
     - name: Install dependencies
       run: |
-        opam install extlib camlzip zarith ocamlbuild odoc goblint-cil.2.0.6
+        opam install --deps-only ./CodeHawk/codehawk.opam 
+        opam install odoc
     - name: Build executables
       run: eval $(opam env) && cd CodeHawk && dune build @install
     - name: Build documentation

--- a/CodeHawk/README.md
+++ b/CodeHawk/README.md
@@ -52,7 +52,7 @@ git clone https://github.com/static-analysis-engineering/codehawk.git
 cd codehawk/CodeHawk
 opam switch create . 5.2.0
 eval $(opam env)
-opam install dune ocamlfind zarith camlzip extlib goblint-cil.2.0.6
+opam install --deps-only ./codehawk.opam
 
 dune build @install
 ```

--- a/CodeHawk/codehawk.opam
+++ b/CodeHawk/codehawk.opam
@@ -1,0 +1,20 @@
+opam-version: "2.0"
+maintainer: "hsipma@aarno-labs.com"
+authors: ["Henny B. Sipma" "A. Cody Schuffelen" "Anca Browne"
+          "Andrew McGraw" "Arnaud Venet" "Aarno Labs LLC"]
+synopsis: "CodeHawk Abstract Interpretation Engine and Analyzers"
+license: "MIT"
+homepage: "https://github.com/static-analysis-engineering/codehawk"
+bug-reports: "https://github.com/static-analysis-engineering/codehawk/issues"
+dev-repo: "git+https://github.com/static-analysis-engineering/codehawk.git"
+
+depends: [
+  "ocaml"         {< "5.3.0"}
+  "dune"          {>= "3.0"}
+  "ocamlfind"
+  "zarith"
+  "camlzip"
+  "extlib"
+  "goblint-cil"   {= "2.0.6"}
+]
+


### PR DESCRIPTION
This centralizes dependency information in a machine-legible format, reducing the number of places that need modification when dependencies are changed, and enabling outside tools like Tenjin to more easily integrate with CodeHawk.